### PR TITLE
Add navigation tabs and portfolio preview page

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,12 +9,16 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
-<body>
-  <div class="page">
-    <header class="header">
-      <h1><span class="hash">#</span> Adam <span class="braces">{</span><span class="accent">Bednarek</span><span class="braces">}</span></h1>
-      <p class="sub">A focused, minimal resume.</p>
-    </header>
+  <body>
+    <div class="page">
+      <header class="header">
+        <h1><span class="hash">#</span> Adam <span class="braces">{</span><span class="accent">Bednarek</span><span class="braces">}</span></h1>
+        <p class="sub">A focused, minimal resume.</p>
+      </header>
+      <nav class="tabs">
+        <a href="index.html" class="active">Home</a>
+        <a href="portfolio.html">Portfolio Preview</a>
+      </nav>
 
     <main>
   <section class="panel intro">

--- a/portfolio.html
+++ b/portfolio.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Adam Bednarek - Portfolio Preview</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="page">
+    <header class="header">
+      <h1><span class="hash">#</span> Adam <span class="braces">{</span><span class="accent">Bednarek</span><span class="braces">}</span></h1>
+      <p class="sub">A focused, minimal portfolio preview.</p>
+    </header>
+    <nav class="tabs">
+      <a href="index.html">Home</a>
+      <a href="portfolio.html" class="active">Portfolio Preview</a>
+    </nav>
+
+    <main>
+      <section class="panel">
+        <h2>Shopify POS AI Overlay</h2>
+        <h3>Problem:</h3>
+        <p>Tens of thousands of brick-and-mortar stores still run on outdated POS systems. These merchants often don’t switch due to legacy hardware, employee training gaps, or lack of budget/time to migrate.</p>
+        <h3>Opportunity:</h3>
+        <p>The POS AI Overlay is a browser-based tool that uses OCR and intelligent UI injection to “wrap” outdated systems with modern Shopify functionality—offering real-time sales analytics, low-stock alerts, and multi-location syncing without a full platform migration.</p>
+        <h3>What It Unlocks:</h3>
+        <p>The overlay enables zero downtime during migration, streamlines staff training, lets legacy software users maintain their familiar workflows, and delivers better data management throughout the transition. It can be pitched to businesses as “adding new features to their existing systems” rather than a full migration—positioning it as an easier, low-friction path into the Shopify platform and increasing openness to a complete migration in the future.</p>
+      </section>
+
+      <section class="panel">
+        <h2>Shopify Virtual League</h2>
+        <h3>Problem:</h3>
+        <p>Recreational facilities—such as hockey rinks, basketball gyms, dance studios, and martial arts dojos—often rely on outdated tools to manage sign-ups, payments, schedules, and team coordination. This creates friction for both administrators and users, leading to underutilized time slots, inconsistent engagement, and missed revenue opportunities.</p>
+        <h3>Opportunity:</h3>
+        <p>Shopify Virtual League introduces a hybrid booking, registration, and eCommerce solution designed for participation-based services. Parents can sign up their kids, pay fees, and purchase team merch—all within one integrated platform. Facility owners manage classes, leagues, and events as seamlessly as inventory, streamlining logistics without sacrificing control.</p>
+        <h3>What It Unlocks:</h3>
+        <p>A vertical expansion into service-based commerce, transforming participation-driven businesses into digital storefronts. Shopify becomes the operational backbone of local recreation. As more facilities onboard, Virtual League enables cross-facility collaboration—unlocking province-wide tournaments, shared rosters, and scalable league infrastructure that drives both utilization and community engagement.</p>
+      </section>
+
+      <section class="panel">
+        <h2>Shopify Orbital</h2>
+        <h3>Problem:</h3>
+        <p>Product-based businesses with post-sale service requirements (e.g., hot tubs, signage, large furniture, business software with complex installation) often lose sales due to customer hesitation around managing contractors. Coordinating trades like electricians, landscapers, or installers is overwhelming and unreliable.</p>
+        <h3>Opportunity:</h3>
+        <p>Embed a service orchestration layer into Shopify POS or Shopify Fulfillment to allow sellers to create structured, localized service opportunities post-sale, drawing from a vetted network of contractors.</p>
+        <h3>What It Unlocks:</h3>
+        <p>More completed sales, lower customer churn, and a sticky merchant ecosystem built around post-sale success. Shopify deepens its physical retail moat while creating a defensible contractor marketplace aligned with its merchant base.</p>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>Built with a minimal resume layout.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -80,3 +80,23 @@ input:focus, select:focus, textarea:focus{border-color:var(--green-soft); box-sh
 
 .footer{margin-top:28px; color:var(--muted); font-size:13px}
 .minimal ul{margin:8px 0 0 18px}
+
+.tabs{
+  display:flex;
+  gap:14px;
+  margin-bottom:28px;
+}
+.tabs a{
+  color:var(--text);
+  text-decoration:none;
+  padding:8px 14px;
+  border:1px solid var(--border);
+  border-radius:8px;
+}
+.tabs a.active{
+  background:var(--green);
+  color:#06110d;
+}
+.tabs a:hover{
+  border-color:var(--green-soft);
+}


### PR DESCRIPTION
## Summary
- Add top navigation tabs linking Home and new Portfolio Preview page
- Place tab bar beneath page headers so links are visible
- Create Portfolio Preview page showcasing three Shopify product concepts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ccae115e4832b9a67a335b21efbd1