### PR TITLE
Fix: reliable pdf.js render + overlay sizing + layering

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -41,3 +41,8 @@ input, select{ background:#0e1516; color:var(--text); border:1px solid var(--bor
 .code{ white-space:pre-wrap; font-size:12px; color:#cde; }
 
 .footer{ color:var(--muted); text-align:center; margin-top:24px; }
+
+/* Wizard viewer layering */
+.viewer   { position: relative; }
+.docCanvas{ position: relative; z-index: 1; background: #ffffff; }
+.overlay  { position: absolute; z-index: 2; left: 0; top: 0; pointer-events: auto; }


### PR DESCRIPTION
## Summary
- ensure pdf.js worker is loaded and first PDF page rendered with white background
- sync overlay canvas dimensions with displayed doc for accurate selection
- add CSS rules so overlay sits above document in the wizard viewer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd92cdf304832b9091e4f3404fa6e6