### PR TITLE
Add model selector and improve invoice wizard flow

### DIFF
--- a/invoice-wizard.html
+++ b/invoice-wizard.html
@@ -65,6 +65,14 @@
               <button id="logout-btn" class="btn" type="button">Logout</button>
             </div>
           </div>
+
+          <div class="field">
+            <label for="model-select">Saved Wizard Models</label>
+            <select id="model-select">
+              <option value="">— Select a saved model —</option>
+            </select>
+            <p class="sub">Pick a model and then drop files below to auto-extract.</p>
+          </div>
         </div>
 
         <div id="dropzone" class="dropzone">Drag &amp; Drop Files Here</div>


### PR DESCRIPTION
## Summary
- add "Saved Wizard Models" selector on the dashboard with helpers to save and load models
- introduce step kinds with back/skip controls and a clear finish state to stop looping
- allow batch auto-extraction using a selected model and write confirmed values directly to the results table

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check invoice-wizard.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdba1cf5f8832b833a0f8f85525a08