### PR TITLE
Lock pdf.js worker version and load PDFs from array buffer

### DIFF
--- a/invoice-wizard.html
+++ b/invoice-wizard.html
@@ -8,6 +8,16 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
+  <!-- pdf.js (UMD/legacy build) -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.2.67/pdf.min.js"></script>
+  <script>
+    // Tell pdf.js where to load its worker from (must match the version above)
+    if (window.pdfjsLib && window.pdfjsLib.GlobalWorkerOptions) {
+      window.pdfjsLib.GlobalWorkerOptions.workerSrc =
+        'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.2.67/pdf.worker.min.js';
+    }
+  </script>
+  <script src="https://cdn.jsdelivr.net/npm/tesseract.js@v5.0.4/dist/tesseract.min.js"></script>
 </head>
 <body>
   <div class="page">
@@ -147,9 +157,6 @@
     </footer>
   </div>
 
-  <!-- Script order matters -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.2.67/pdf.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/tesseract.js@4/dist/tesseract.min.js"></script>
   <script src="invoice-wizard.js"></script>
 </body>
 </html>

--- a/invoice-wizard.js
+++ b/invoice-wizard.js
@@ -75,12 +75,24 @@ const els = {
 const pdfjsLibRef = window['pdfjs-dist/build/pdf'] || window['pdfjsLib'];
 const TesseractRef = window.Tesseract;
 
+// Safety net: ensure the worker script matches the loaded pdf.js version.
+try {
+  if (pdfjsLibRef?.version && pdfjsLibRef?.GlobalWorkerOptions) {
+    const v = pdfjsLibRef.version;
+    if (!pdfjsLibRef.GlobalWorkerOptions.workerSrc) {
+      pdfjsLibRef.GlobalWorkerOptions.workerSrc =
+        `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${v}/pdf.worker.min.js`;
+    }
+  }
+} catch (e) {
+  console.warn('Unable to set pdf.js workerSrc dynamically:', e);
+}
+
 let state = {
   username: null,
   docType: 'invoice',
   profile: null,             // Vendor profile (landmarks + fields + tableHints)
   pdf: null,                 // pdf.js document
-  fileBlobUrl: null,
   isImage: false,
   pageNum: 1,
   numPages: 1,
@@ -402,7 +414,6 @@ function extractFieldValue(fieldSpec, tokens, viewportPx){
 }
 
 /* ---------------------- PDF/Image Loading ------------------------ */
-const pdfCtx = els.pdfCanvas.getContext('2d');
 const overlayCtx = els.overlayCanvas.getContext('2d');
 
 function sizeOverlayTo(w,h){
@@ -415,32 +426,35 @@ function updatePageIndicator(){ els.pageIndicator.textContent = `Page ${state.pa
 
 async function openFile(file){
   cleanupDoc();
-  state.currentFileName = file.name;
-  const type = file.type || '';
-  state.isImage = /^image\//.test(type);
-  state.fileBlobUrl = URL.createObjectURL(file);
+  state.currentFileName = file.name || 'untitled.pdf';
+  const isImage = /^image\//.test(file.type || '');
+  state.isImage = isImage;
 
-  if(state.isImage){
+  if (isImage) {
     els.imgCanvas.style.display = 'block';
     els.pdfCanvas.style.display = 'none';
-    await renderImage(state.fileBlobUrl);
+    const blobUrl = URL.createObjectURL(file);
+    await renderImage(blobUrl);
     state.pageNum = 1; state.numPages = 1;
     updatePageIndicator();
     document.getElementById('pageControls').style.display = 'flex';
     await ensureTokensForPage(1);
-  } else {
-    els.imgCanvas.style.display = 'none';
-    els.pdfCanvas.style.display = 'block';
-    const loadingTask = pdfjsLibRef.getDocument({ url: state.fileBlobUrl });
-    state.pdf = await loadingTask.promise;
-    state.pageNum = 1; state.numPages = state.pdf.numPages;
-    updatePageIndicator();
-    document.getElementById('pageControls').style.display = 'flex';
-    await renderPage(state.pageNum);
+    return;
   }
+
+  // PDF
+  els.imgCanvas.style.display = 'none';
+  els.pdfCanvas.style.display = 'block';
+
+  const arrayBuffer = await file.arrayBuffer();
+  const loadingTask = pdfjsLibRef.getDocument({ data: arrayBuffer });
+  state.pdf = await loadingTask.promise;
+  state.pageNum = 1; state.numPages = state.pdf.numPages;
+  updatePageIndicator();
+  document.getElementById('pageControls').style.display = 'flex';
+  await renderPage(state.pageNum);
 }
 function cleanupDoc(){
-  if(state.fileBlobUrl){ URL.revokeObjectURL(state.fileBlobUrl); }
   state.tokensByPage = {};
   state.selectionPx = null; state.snappedPx = null; state.snappedText = '';
   overlayCtx.clearRect(0,0,els.overlayCanvas.width, els.overlayCanvas.height);
@@ -453,19 +467,28 @@ async function renderImage(url){
     img.height = img.naturalHeight * scale;
     sizeOverlayTo(img.width, img.height);
     state.viewport = { w: img.width, h: img.height, scale };
+    URL.revokeObjectURL(url);
   };
   img.src = url;
 }
 async function renderPage(num){
+  if (!state.pdf) return;
   const page = await state.pdf.getPage(num);
   const scale = 1.5;
-  const vp = page.getViewport({ scale });
-  els.pdfCanvas.width = vp.width;
-  els.pdfCanvas.height = vp.height;
-  sizeOverlayTo(vp.width, vp.height);
-  state.viewport = { w: vp.width, h: vp.height, scale };
-  await page.render({ canvasContext: pdfCtx, viewport: vp }).promise;
-  await ensureTokensForPage(num, page, vp);
+  const viewport = page.getViewport({ scale });
+  els.pdfCanvas.width = viewport.width;
+  els.pdfCanvas.height = viewport.height;
+
+  // Make sure CSS doesn’t override the canvas size
+  els.pdfCanvas.style.width = viewport.width + 'px';
+  els.pdfCanvas.style.height = viewport.height + 'px';
+
+  sizeOverlayTo(viewport.width, viewport.height);
+  state.viewport = { w: viewport.width, h: viewport.height, scale };
+  const ctx = els.pdfCanvas.getContext('2d', { willReadFrequently: true });
+
+  await page.render({ canvasContext: ctx, viewport }).promise;
+  await ensureTokensForPage(num, page, viewport);
 }
 
 /* ----------------------- Text Extraction ------------------------- */


### PR DESCRIPTION
## Summary
- load pdf.js and its worker from the same CDN version and upgrade tesseract
- guard against worker misconfig and default to matching worker version
- open PDFs from ArrayBuffer and ensure canvas dimensions are set before rendering

## Testing
- `node --check invoice-wizard.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdc719f494832b8868276d04aba921