### PR TITLE
Fix PDF.js import path for invoice wizard

### DIFF
--- a/invoice-wizard.html
+++ b/invoice-wizard.html
@@ -12,13 +12,13 @@
   <link rel="stylesheet" href="styles.css">
 
   <!-- pdf.js (same-origin, single version) -->
-<script src="/vendor/pdfjs/3.10.111/pdf.min.js"></script>
-<script>
-  // Match the worker to the SAME version & same origin
-  if (window.pdfjsLib && window.pdfjsLib.GlobalWorkerOptions) {
-    window.pdfjsLib.GlobalWorkerOptions.workerSrc = '/vendor/pdfjs/3.10.111/pdf.worker.min.js';
-  }
-</script>
+  <script src="vendor/pdfjs/3.10.111/pdf.min.js"></script>
+  <script>
+    // Match the worker to the SAME version & same origin
+    if (window.pdfjsLib && window.pdfjsLib.GlobalWorkerOptions) {
+      window.pdfjsLib.GlobalWorkerOptions.workerSrc = 'vendor/pdfjs/3.10.111/pdf.worker.min.js';
+    }
+  </script>
 
 
 


### PR DESCRIPTION
## Summary
- fix pdf.js script and worker paths to be relative so the wizard can load them correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf31ea5bc832b830df10ec47fee3e