### PR TITLE
Enable dashboard buttons

### DIFF
--- a/invoice-wizard.html
+++ b/invoice-wizard.html
@@ -80,10 +80,10 @@
             <div class="field">
               <label>Quick Actions</label>
               <div class="actions">
-                <button id="configure-btn" class="btn">Configure Wizard</button>
-                <button id="new-wizard-btn" class="btn" style="display:none">New Wizard</button>
-                <button id="demo-btn" class="btn">Demo Wizard</button>
-                <button id="upload-btn" class="btn" style="display:none">Upload Documents</button>
+                <button id="configure-btn" class="btn" type="button">Configure Wizard</button>
+                <button id="new-wizard-btn" class="btn" style="display:none" type="button">New Wizard</button>
+                <button id="demo-btn" class="btn" type="button">Demo Wizard</button>
+                <button id="upload-btn" class="btn" style="display:none" type="button">Upload Documents</button>
                 <button id="reset-model-btn" class="btn" type="button">Reset Model</button>
                 <button id="logout-btn" class="btn" type="button">Logout</button>
               </div>

--- a/invoice-wizard.js
+++ b/invoice-wizard.js
@@ -232,6 +232,43 @@
     }
   }
 
+  // UI helpers for the browser dashboard
+  let appInitialized = false;
+  function initApp(){
+    if(appInitialized) return;
+    appInitialized = true;
+
+    const tabs = document.querySelectorAll('#dashTabs .tablink');
+    const sections = Array.from(tabs).map(b => b.dataset.target);
+    tabs.forEach(btn => {
+      btn.addEventListener('click', () => {
+        tabs.forEach(b => b.classList.toggle('active', b === btn));
+        sections.forEach(id => {
+          const el = document.getElementById(id);
+          if(el) el.style.display = id === btn.dataset.target ? 'block' : 'none';
+        });
+      });
+    });
+
+    const app = document.getElementById('app');
+    const wizard = document.getElementById('wizard-section');
+    function showWizard(){ if(app) app.style.display='none'; if(wizard) wizard.style.display='block'; }
+    function showDashboard(){ if(wizard) wizard.style.display='none'; if(app) app.style.display='block'; }
+
+    const configureBtn = document.getElementById('configure-btn');
+    const demoBtn = document.getElementById('demo-btn');
+    const newBtn = document.getElementById('new-wizard-btn');
+    [configureBtn,demoBtn,newBtn].forEach(btn => {
+      if(btn) btn.addEventListener('click', showWizard);
+    });
+
+    const backBtn = document.getElementById('backBtn');
+    const finishBtn = document.getElementById('finishWizardBtn');
+    [backBtn, finishBtn].forEach(btn => {
+      if(btn) btn.addEventListener('click', showDashboard);
+    });
+  }
+
   // Optional browser login toggles used by the UI
   function initLogin(){
     if (typeof window === 'undefined') return;
@@ -245,6 +282,7 @@
     function showApp(){
       if(loginSection) loginSection.style.display = 'none';
       if(app) app.style.display = 'block';
+      initApp();
     }
 
     function showLogin(){

--- a/tests/dashboard.test.js
+++ b/tests/dashboard.test.js
@@ -1,0 +1,61 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { JSDOM } = require('jsdom');
+const engine = require('../invoice-wizard.js');
+
+test('dashboard buttons switch views', () => {
+  const dom = new JSDOM(`
+    <section id="login-section">
+      <form id="login-form">
+        <input id="username" />
+        <input id="password" type="password" />
+      </form>
+    </section>
+    <section id="app" style="display:none">
+      <nav id="dashTabs">
+        <button class="tablink active" data-target="document-dashboard">Document Dashboard</button>
+        <button class="tablink" data-target="reports">Reports</button>
+      </nav>
+      <section id="document-dashboard" style="display:block">
+        <div class="actions">
+          <button id="configure-btn" type="button"></button>
+        </div>
+      </section>
+      <section id="reports" style="display:none"></section>
+    </section>
+    <section id="wizard-section" style="display:none">
+      <button id="finishWizardBtn" type="button"></button>
+      <button id="backBtn" type="button"></button>
+    </section>
+  `, { url: 'http://localhost' });
+
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.localStorage = dom.window.localStorage;
+
+  engine.initLogin();
+
+  // simulate login
+  document.getElementById('username').value = 'alice';
+  document.getElementById('password').value = 'pw';
+  document.getElementById('login-form').dispatchEvent(new dom.window.Event('submit', { bubbles:true, cancelable:true }));
+
+  // dashboard tab switch
+  document.querySelector('#dashTabs .tablink[data-target="reports"]').click();
+  assert.equal(document.getElementById('reports').style.display, 'block');
+  assert.equal(document.getElementById('document-dashboard').style.display, 'none');
+
+  // configure wizard
+  document.getElementById('configure-btn').click();
+  assert.equal(document.getElementById('app').style.display, 'none');
+  assert.equal(document.getElementById('wizard-section').style.display, 'block');
+
+  // return
+  document.getElementById('finishWizardBtn').click();
+  assert.equal(document.getElementById('wizard-section').style.display, 'none');
+  assert.equal(document.getElementById('app').style.display, 'block');
+
+  delete global.window;
+  delete global.document;
+  delete global.localStorage;
+});


### PR DESCRIPTION
## Summary
- Initialize dashboard controls after login
- Fix quick action button types
- Add regression test for dashboard interactions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf080505e0832bb6469fb1543e892c