### PR TITLE
Improve scalar value cleaning and normalization

### DIFF
--- a/invoice-wizard.js
+++ b/invoice-wizard.js
@@ -193,8 +193,46 @@ function collapseAdjacentDuplicates(str){
   return out;
 }
 
+function normalizeMoney(raw){
+  if(!raw) return '';
+  const sign = /-/.test(raw) ? '-' : '';
+  const cleaned = raw.replace(/[^0-9.,]/g, '').replace(/,/g,'');
+  const num = parseFloat(cleaned);
+  if(isNaN(num)) return '';
+  const abs = Math.abs(num).toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  });
+  return sign + abs;
+}
+
+function normalizeDate(raw){
+  if(!raw) return '';
+  const txt = raw.trim().replace(/(\d)(st|nd|rd|th)/gi, '$1');
+  const months = {
+    jan:1,feb:2,mar:3,apr:4,may:5,jun:6,jul:7,aug:8,sep:9,oct:10,nov:11,dec:12
+  };
+  let y,m,d;
+  let match;
+  if((match = txt.match(/^(\d{4})[\/-](\d{1,2})[\/-](\d{1,2})$/))){
+    y = +match[1]; m = +match[2]; d = +match[3];
+  } else if((match = txt.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/))){
+    const a = +match[1], b = +match[2];
+    // if first part >12 assume DD/MM/YYYY else MM/DD/YYYY
+    if(a > 12){ d = a; m = b; } else { m = a; d = b; }
+    y = +match[3];
+  } else if((match = txt.match(/^([A-Za-z]{3,9})\s+(\d{1,2}),\s*(\d{4})$/))){
+    m = months[match[1].slice(0,3).toLowerCase()] || 0;
+    d = +match[2];
+    y = +match[3];
+  }
+  if(!y || !m || !d) return '';
+  const pad = n => n.toString().padStart(2,'0');
+  return `${y}-${pad(m)}-${pad(d)}`;
+}
+
 function cleanScalarValue(raw, fieldKey=''){
-  let txt = (raw || '').replace(/[:#]*$/, '').trim();
+  let txt = (raw || '').replace(/[#:—•]*$/, '').trim();
   const label = fieldKey.replace(/_/g,' ');
   if(label){
     const labelRe = new RegExp(`^${label}\\s*[:#-]?\\s*`, 'i');
@@ -202,6 +240,17 @@ function cleanScalarValue(raw, fieldKey=''){
     if(txt.toLowerCase() === label.toLowerCase()) txt = '';
   }
   txt = collapseAdjacentDuplicates(txt).replace(/\s+/g,' ').trim();
+
+  if(/date/i.test(fieldKey)){
+    const norm = normalizeDate(txt);
+    if(norm) txt = norm;
+  } else if(/total|subtotal|tax|amount|price|balance|deposit|discount|unit|grand/i.test(fieldKey)){
+    const norm = normalizeMoney(txt);
+    if(norm) txt = norm;
+  } else if(/sku|product_code/i.test(fieldKey)){
+    txt = txt.replace(/\s+/g,'').toUpperCase();
+  }
+
   return txt;
 }
 


### PR DESCRIPTION
## Summary
- add money and date normalization helpers
- enhance generic scalar value cleanup and token dedupe

## Testing
- `node --check invoice-wizard.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf3c1317d4832baf31912876e17556