### PR TITLE
feat: add field typing and calibration landmarks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,3 +115,9 @@ Tunable Behaviors (plain language)
 “Micro-expansion size”: a very small padding added around the bbox, applied in a few steps, with a modest cap.
 “Same-line band”: the vertical thickness considered “same line” when walking right from a label.
 “Tolerance”: allowed difference for arithmetic checks (e.g., a few cents or a small percent).
+
+## Field Types & Landmarks
+Fields are tagged as **static** or **column**. Static fields store an edge-based ring fingerprint (normalized luminance + Sobel edges) and an offset to the value box. During extraction the ring is searched only near the saved bbox (±25% of page height). If the ring is found, the offset is applied to read the value; if not, the engine falls back to the bbox and nearby anchor words. Column fields save an x-band, line height, header info, and guard words. Extraction scans tokens inside each band, removes headers, groups by row, merges wrapped descriptions, and stops at guard words.
+
+## Confidence
+Static field confidence blends the ring match score, anchor proximity, grammar checks, and arithmetic consistency (e.g., subtotal + tax ≈ total). Column row confidence is the minimum of its column confidences with penalties for misalignment across columns. Low-confidence results are surfaced in the UI with a ⚠️ marker so users can review or override the value.

--- a/invoice-wizard.html
+++ b/invoice-wizard.html
@@ -117,7 +117,20 @@
               Show saved boxes
             </label>
           </div>
+          <div class="field">
+            <label style="flex-direction:row;align-items:center;gap:6px;">
+              <input type="checkbox" id="show-rings-toggle" class="show-ring-toggle" />
+              Show ring landmarks
+            </label>
+          </div>
+          <div class="field">
+            <label style="flex-direction:row;align-items:center;gap:6px;">
+              <input type="checkbox" id="show-match-toggle" class="show-match-toggle" />
+              Show match points
+            </label>
+          </div>
           <div id="resultsMount"></div>
+          <pre id="telemetryPanel" class="code" style="max-height:120px;overflow:auto;"></pre>
         </section>
 
         <section id="reports" class="panel" style="display:none">
@@ -142,6 +155,14 @@
           <label style="margin-left:12px; display:flex; align-items:center; gap:6px;">
             <input type="checkbox" id="ocrToggle" checked>
             Run OCR on confirm
+          </label>
+          <label style="margin-left:12px; display:flex; align-items:center; gap:6px;">
+            <input type="checkbox" id="show-rings-wizard" class="show-ring-toggle" />
+            Show ring landmarks
+          </label>
+          <label style="margin-left:12px; display:flex; align-items:center; gap:6px;">
+            <input type="checkbox" id="show-match-wizard" class="show-match-toggle" />
+            Show match points
           </label>
         </div>
 

--- a/styles.css
+++ b/styles.css
@@ -53,5 +53,6 @@ input, select{ background:#0e1516; color:var(--text); border:1px solid var(--bor
 
 /* Extraction / results */
 .confidence{ font-size:10px; color:var(--muted); margin-left:4px; }
+.warn{ color:var(--accent); font-size:12px; margin-left:2px; }
 .line-items-table{ width:100%; border-collapse:collapse; font-size:12px; }
 .line-items-table th, .line-items-table td{ border-bottom:1px solid var(--border); padding:4px; }


### PR DESCRIPTION
## Summary
- harden ring landmarks by normalizing luminance and storing Sobel edge maps
- compare edge fingerprints with ZNCC/Hamming and log comparator-based confidence
- document that static fields use edge-based ring fingerprints for robust matching

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check invoice-wizard.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4667bdd90832b8fc5a6b086820305