### PR TITLE
Fix highlight selection in configuration wizard

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -40,7 +40,7 @@ input, select{ background:#0e1516; color:var(--text); border:1px solid var(--bor
 .prompt{ display:flex; align-items:center; gap:12px; margin:10px 0; }
 .viewer{ position:relative; display:block; overflow:auto; max-height:70vh; padding:8px; border:1px dashed var(--border); border-radius:12px; background:#0b1111; }
 .docCanvas{ display:block; max-width:100%; height:auto; }
-.overlay{ position:absolute; left:0; top:0; pointer-events:none; }
+.overlay{ position:absolute; left:0; top:0; pointer-events:auto; }
 
 .code{ white-space:pre-wrap; font-size:12px; color:#cde; }
 
@@ -49,7 +49,7 @@ input, select{ background:#0e1516; color:var(--text); border:1px solid var(--bor
 /* Wizard viewer layering */
 .viewer   { position: relative; }
 .docCanvas{ position: relative; z-index: 1; background: #ffffff; }
-.overlay  { position: absolute; z-index: 2; left: 0; top: 0; pointer-events: none; }
+.overlay  { position: absolute; z-index: 2; left: 0; top: 0; pointer-events: auto; }
 
 /* Extraction / results */
 .confidence{ font-size:10px; color:var(--muted); margin-left:4px; }


### PR DESCRIPTION
## Summary
- Enable pointer events on overlay canvas so users can draw bounding boxes again

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4937f45f4832b84f03b9c86da915f