### PR TITLE
feat: add OCR crop diagnostics

### DIFF
--- a/invoice-wizard.html
+++ b/invoice-wizard.html
@@ -129,8 +129,18 @@
               Show match points
             </label>
           </div>
+          <div class="field">
+            <label style="flex-direction:row;align-items:center;gap:6px;">
+              <input type="checkbox" id="show-ocr-boxes-toggle" />
+              Show OCR Boxes
+            </label>
+          </div>
           <div id="resultsMount"></div>
           <pre id="telemetryPanel" class="code" style="max-height:120px;overflow:auto;"></pre>
+          <div id="ocrCropSelfTest" class="panel minimal">
+            <h3>OCR Crop Self-Test</h3>
+            <div id="ocrCropList"></div>
+          </div>
         </section>
 
         <section id="reports" class="panel" style="display:none">


### PR DESCRIPTION
## Summary
- add UI toggle and panel for OCR crop self-test
- save crop images and JSON with dual-pass OCR probes and guards
- show crop overlays on canvas and log guard results

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c500d3d9e4832ba2cedf460855f03a