### PR TITLE
Fix OCR crop geometry and add self-test diagnostics

### DIFF
--- a/invoice-wizard.html
+++ b/invoice-wizard.html
@@ -131,7 +131,7 @@
           </div>
           <div class="field">
             <label style="flex-direction:row;align-items:center;gap:6px;">
-              <input type="checkbox" id="show-ocr-boxes-toggle" />
+              <input type="checkbox" id="show-ocr-boxes-toggle" checked />
               Show OCR Boxes
             </label>
           </div>


### PR DESCRIPTION
## Summary
- centralize crop logic with device pixel ratio, viewport scale, and rotation handling
- run dual-pass OCR probes (PSM6 & PSM7) across multiple paddings
- add debug panel with A/B/C thumbnails and per-pass metrics
- enable Show OCR Boxes debug overlay by default

## Testing
- `node --check invoice-wizard.js`


------
https://chatgpt.com/codex/tasks/task_e_68c50ac03db8832b9c6a91f92e2432b8