### PR TITLE
Rebuild crop geometry pipeline with robust validations

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -61,4 +61,5 @@ canvas.debug-crop, #pdfCanvas{ background:none !important; }
 .ocrCropRow{ display:flex; align-items:flex-start; gap:8px; margin-bottom:6px; }
 .ocrCropRow img{ width:80px; height:auto; max-height:80px; border:1px solid var(--border); background:#fff; }
 .ocrCropRow .badge{ font-size:11px; padding:2px 4px; background:#222; border:1px solid var(--border); border-radius:4px; }
+.ocrCropRow .badge.warn{ background:#ffea00; color:#000; }
 .ocrGeom{ font-size:10px; color:var(--muted); }


### PR DESCRIPTION
## Summary
- add normalized box validation and canonical mapping to device pixels
- track render readiness and verify crop source canvas
- surface crop telemetry with error badges and red overlay boxes

## Testing
- `node --check invoice-wizard.js`
- `npx -y prettier -c invoice-wizard.js styles.css` *(fails: code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ab7f0e2c832b811bc6854a96334b