### PR TITLE
Fix viewport dimension usage in crop normalization

### DIFF
--- a/invoice-wizard.js
+++ b/invoice-wizard.js
@@ -173,8 +173,28 @@ const migrations = {
   3: p => {
     (p.fields||[]).forEach(f=>{
       if(f.normBox){
-        const chk = validateSelection(f.normBox);
-        if(!chk.ok){ f.boxError = chk.reason; }
+        let chk = validateSelection(f.normBox);
+        if(!chk.ok){
+          let nb = null;
+          if(f.bboxPct){
+            const tmp = { x0n:f.bboxPct.x0, y0n:f.bboxPct.y0, wN:f.bboxPct.x1 - f.bboxPct.x0, hN:f.bboxPct.y1 - f.bboxPct.y0 };
+            const v = validateSelection(tmp);
+            if(v.ok) nb = v.normBox;
+          }
+          if(!nb && f.rawBox){
+            const v = validateSelection(f.rawBox);
+            if(v.ok) nb = v.normBox;
+          }
+          if(nb){
+            f.normBox = nb;
+            delete f.boxError;
+            if(!f.bboxPct){
+              f.bboxPct = { x0: nb.x0n, y0: nb.y0n, x1: nb.x0n + nb.wN, y1: nb.y0n + nb.hN };
+            }
+          } else {
+            f.boxError = chk.reason;
+          }
+        }
         return;
       }
       const rb = f.rawBox;
@@ -812,7 +832,27 @@ function ensureProfile(){
     state.profile.fields.forEach(f=>{
       if(f.normBox){
         const chk = validateSelection(f.normBox);
-        if(!chk.ok){ f.boxError = chk.reason; }
+        if(!chk.ok){
+          let nb = null;
+          if(f.bboxPct){
+            const tmp = { x0n:f.bboxPct.x0, y0n:f.bboxPct.y0, wN:f.bboxPct.x1 - f.bboxPct.x0, hN:f.bboxPct.y1 - f.bboxPct.y0 };
+            const v = validateSelection(tmp);
+            if(v.ok) nb = v.normBox;
+          }
+          if(!nb && f.rawBox){
+            const v = validateSelection(f.rawBox);
+            if(v.ok) nb = v.normBox;
+          }
+          if(nb){
+            f.normBox = nb;
+            delete f.boxError;
+            if(!f.bboxPct){
+              f.bboxPct = { x0: nb.x0n, y0: nb.y0n, x1: nb.x0n + nb.wN, y1: nb.y0n + nb.hN };
+            }
+          } else {
+            f.boxError = chk.reason;
+          }
+        }
       } else if(f.rawBox){
         const chk = validateSelection(f.rawBox);
         if(chk.ok){
@@ -1560,7 +1600,9 @@ async function auditCropSelfTest(question, boxPx){
   const docId = (state.currentFileName || 'doc').replace(/[^a-z0-9_-]/gi,'_');
   const pageIndex = (boxPx.page||1) - 1;
   const vp = state.pageViewports[pageIndex] || state.viewport || {width:1,height:1};
-  const normBox = normalizeBox(boxPx, vp.width || 1, vp.height || 1);
+  const canvasW = (vp.width ?? vp.w) || 1;
+  const canvasH = (vp.height ?? vp.h) || 1;
+  const normBox = normalizeBox(boxPx, canvasW, canvasH);
   const { cropBitmap, meta } = getOcrCropForSelection({ docId, pageIndex, normBox });
   meta.question = question;
   const fs = window.fs || (window.require && window.require('fs'));
@@ -2727,8 +2769,8 @@ els.confirmBtn?.addEventListener('click', async ()=>{
   }
 
   const vp = state.pageViewports[state.pageNum-1] || state.viewport || {width:1,height:1};
-  const canvasW = vp.width || 1;
-  const canvasH = vp.height || 1;
+  const canvasW = (vp.width ?? vp.w) || 1;
+  const canvasH = (vp.height ?? vp.h) || 1;
   const normBox = normalizeBox(boxPx, canvasW, canvasH);
   const pct = { x0: normBox.x0n, y0: normBox.y0n, x1: normBox.x0n + normBox.wN, y1: normBox.y0n + normBox.hN };
   const rawBoxData = { x: boxPx.x, y: boxPx.y, w: boxPx.w, h: boxPx.h, canvasW, canvasH };
@@ -2795,7 +2837,7 @@ async function autoExtractFileWithProfile(file, profile){
     const { value, boxPx, confidence, raw, corrections } = await extractFieldValue(fieldSpec, tokens, state.viewport);
     if(value){
       const vp = state.pageViewports[state.pageNum-1] || state.viewport || {width:1,height:1};
-      const nb = boxPx ? normalizeBox(boxPx, vp.width || 1, vp.height || 1) : null;
+      const nb = boxPx ? normalizeBox(boxPx, (vp.width ?? vp.w) || 1, (vp.height ?? vp.h) || 1) : null;
       const pct = nb ? { x0: nb.x0n, y0: nb.y0n, x1: nb.x0n + nb.wN, y1: nb.y0n + nb.hN } : null;
       const arr = rawStore[state.currentFileId];
       let conf = confidence;


### PR DESCRIPTION
## Summary
- normalize crop boxes using either width/height or w/h from the current viewport
- ensure saved selections and self-test crops use correct canvas dimensions for images
- rebuild invalid saved crop boxes from bboxPct or rawBox so trace viewer can render crops

## Testing
- `node --check invoice-wizard.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b6338168832b8e0a3c7ba04a3b41