### PR TITLE
Add traceEvent helper and instrument extraction pipeline

### DIFF
--- a/trace.js
+++ b/trace.js
@@ -38,4 +38,13 @@
   global.TraceStore=TraceStore;
   global.debugTraces=new TraceStore();
   global.exportTraceFile=exportTraceFile;
+  const _traceMap=new Map();
+  function _spanKeyKey(k){ return `${k?.docId||''}:${k?.pageIndex||0}:${k?.fieldKey||''}`; }
+  global.traceEvent=function(spanKey, stage, payload={}){
+    if(!global.debugTraces||!spanKey||!stage) return;
+    const key=_spanKeyKey(spanKey);
+    let id=_traceMap.get(key);
+    if(!id){ id=global.debugTraces.start(spanKey); _traceMap.set(key,id); }
+    global.debugTraces.add(id, stage, { output: payload });
+  };
 })(window);


### PR DESCRIPTION
## Summary
- add global `traceEvent` helper mapping events by spanKey
- instrument invoice wizard to emit standardized events across OCR, cleaning, fallback, line-item parsing and saves

## Testing
- `node test/orchestrator.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5c29ac1c0832bbb0c2c57d6e0cb24