### PR TITLE
Add interactive trace viewer with filtering and overlays

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -69,3 +69,8 @@ canvas.debug-crop, #pdfCanvas{ background:none !important; }
 .traceStage{ cursor:pointer; padding:2px 0; }
 .traceStage:hover{ background:#222; }
 #traceDetail{ max-height:160px; overflow:auto; }
+
+/* Trace viewer page */
+#thumbs img.thumb{ width:80px; height:auto; margin:4px; border:1px solid var(--border); cursor:pointer; }
+#thumbs img.thumb.selected{ border-color:var(--accent); }
+#overlayControls{ margin:8px 0; display:flex; gap:8px; align-items:center; flex-wrap:wrap; }

--- a/trace-viewer.html
+++ b/trace-viewer.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Trace Viewer</title>
+  <link rel="stylesheet" href="styles.css">
+  <script src="trace.js"></script>
+  <script src="trace-viewer.js" defer></script>
+</head>
+<body>
+  <h2>Trace Viewer</h2>
+  <div id="filters">
+    <label>Doc <select id="docFilter"></select></label>
+    <label>Field <select id="fieldFilter"></select></label>
+    <label>Stage <select id="stageFilter"></select></label>
+  </div>
+  <div id="thumbs"></div>
+  <div id="viewer">
+    <div id="overlayControls">
+      <label><input type="checkbox" id="ovSel" checked>Selection</label>
+      <label><input type="checkbox" id="ovTok">Tokens</label>
+      <label><input type="checkbox" id="ovAnc">Anchors</label>
+      <label><input type="checkbox" id="ovHeat">Heatmap</label>
+      <button id="copyTraceBtn" class="btn">Copy trace JSON</button>
+    </div>
+    <div id="imgWrap" style="position:relative">
+      <img id="detailImg" />
+      <canvas id="ovCanvas" style="position:absolute;left:0;top:0;"></canvas>
+    </div>
+    <pre id="eventJson" class="code"></pre>
+  </div>
+</body>
+</html>

--- a/trace-viewer.js
+++ b/trace-viewer.js
@@ -1,0 +1,122 @@
+(function(){
+  const traces = window.debugTraces?.traces || [];
+  const els = {
+    docFilter: document.getElementById('docFilter'),
+    fieldFilter: document.getElementById('fieldFilter'),
+    stageFilter: document.getElementById('stageFilter'),
+    thumbs: document.getElementById('thumbs'),
+    detailImg: document.getElementById('detailImg'),
+    ovCanvas: document.getElementById('ovCanvas'),
+    eventJson: document.getElementById('eventJson'),
+    copyBtn: document.getElementById('copyTraceBtn'),
+    ovSel: document.getElementById('ovSel'),
+    ovTok: document.getElementById('ovTok'),
+    ovAnc: document.getElementById('ovAnc'),
+    ovHeat: document.getElementById('ovHeat')
+  };
+  function populate(sel, items){
+    const opt = document.createElement('option');
+    opt.value=''; opt.textContent='(all)';
+    sel.appendChild(opt);
+    items.forEach(v=>{ const o=document.createElement('option'); o.value=v; o.textContent=v; sel.appendChild(o); });
+  }
+  function initFilters(){
+    populate(els.docFilter, Array.from(new Set(traces.map(t=>t.spanKey.docId))));
+    populate(els.fieldFilter, Array.from(new Set(traces.map(t=>t.spanKey.fieldKey))));
+    populate(els.stageFilter, Array.from(new Set(traces.flatMap(t=>t.events.map(e=>e.stage)))));
+    els.docFilter.onchange=renderThumbs;
+    els.fieldFilter.onchange=renderThumbs;
+    els.stageFilter.onchange=renderThumbs;
+  }
+  function renderThumbs(){
+    const doc=els.docFilter.value;
+    const field=els.fieldFilter.value;
+    const stage=els.stageFilter.value;
+    els.thumbs.innerHTML='';
+    traces.forEach(t=>{
+      if(doc && t.spanKey.docId!==doc) return;
+      if(field && t.spanKey.fieldKey!==field) return;
+      t.events.forEach((ev,i)=>{
+        if(stage && ev.stage!==stage) return;
+        if(!ev.artifact) return;
+        const img=document.createElement('img');
+        img.src=ev.artifact;
+        img.className='thumb';
+        img.dataset.traceId=t.traceId;
+        img.dataset.index=i;
+        img.onclick=()=>showEvent(t.traceId,i,img);
+        els.thumbs.appendChild(img);
+      });
+    });
+  }
+  function showEvent(traceId,index,thumb){
+    const trace=debugTraces.get(traceId); if(!trace) return;
+    const ev=trace.events[index];
+    els.detailImg.onload=()=>{ resizeCanvas(); drawOverlays(ev); };
+    els.detailImg.src=ev.artifact||'';
+    els.eventJson.textContent=JSON.stringify(ev,null,2);
+    [...els.thumbs.querySelectorAll('img')].forEach(im=>im.classList.remove('selected'));
+    if(thumb) thumb.classList.add('selected');
+    els.copyBtn.onclick=()=>copyTraceJson(traceId);
+  }
+  function resizeCanvas(){
+    const w=els.detailImg.naturalWidth;
+    const h=els.detailImg.naturalHeight;
+    els.ovCanvas.width=w;
+    els.ovCanvas.height=h;
+    els.ovCanvas.style.width=els.detailImg.width+'px';
+    els.ovCanvas.style.height=els.detailImg.height+'px';
+  }
+  function drawOverlays(ev){
+    const ctx=els.ovCanvas.getContext('2d');
+    ctx.clearRect(0,0,els.ovCanvas.width,els.ovCanvas.height);
+    if(els.ovSel.checked){
+      const b=ev.input?.boxPx||ev.input?.normBox||ev.output?.rect;
+      if(b){
+        const w=els.ovCanvas.width;
+        const h=els.ovCanvas.height;
+        let x=b.x||b.x0||(b.x0n*w)||0;
+        let y=b.y||b.y0||(b.y0n*h)||0;
+        let bw=b.w||(b.wN*w)||b.sw||0;
+        let bh=b.h||(b.hN*h)||b.sh||0;
+        ctx.strokeStyle='lime'; ctx.lineWidth=2;
+        ctx.strokeRect(x,y,bw,bh);
+      }
+    }
+    if(els.ovTok.checked && ev.output?.tokens){
+      ev.output.tokens.forEach(tok=>{
+        const b=tok.box||tok;
+        const x=b.x||b.x0||0, y=b.y||b.y0||0;
+        const w=b.w||(b.x1?b.x1-b.x0:0), h=b.h||(b.y1?b.y1-b.y0:0);
+        if(els.ovHeat.checked){
+          const conf=tok.conf||tok.confidence||0;
+          const col=`rgba(${Math.round((1-conf)*255)},${Math.round(conf*255)},0,0.3)`;
+          ctx.fillStyle=col; ctx.fillRect(x,y,w,h);
+        }
+        ctx.strokeStyle='yellow';
+        ctx.strokeRect(x,y,w,h);
+      });
+    }
+    if(els.ovAnc.checked && ev.output?.anchors){
+      ctx.strokeStyle='red';
+      ev.output.anchors.forEach(a=>{
+        const b=a.box||a;
+        const x=b.x||b.x0||0, y=b.y||b.y0||0;
+        const w=b.w||(b.x1?b.x1-b.x0:0), h=b.h||(b.y1?b.y1-b.y0:0);
+        ctx.strokeRect(x,y,w,h);
+      });
+    }
+  }
+  ['ovSel','ovTok','ovAnc','ovHeat'].forEach(id=>{
+    els[id].addEventListener('change',()=>{
+      const sel=els.thumbs.querySelector('img.selected');
+      if(!sel) return;
+      const tr=sel.dataset.traceId;
+      const idx=parseInt(sel.dataset.index);
+      const ev=debugTraces.get(tr).events[idx];
+      drawOverlays(ev);
+    });
+  });
+  initFilters();
+  renderThumbs();
+})();

--- a/trace.js
+++ b/trace.js
@@ -35,9 +35,21 @@
     document.body.appendChild(a); a.click(); document.body.removeChild(a);
     setTimeout(()=>URL.revokeObjectURL(url),1000);
   }
+  function copyTraceJson(traceId){
+    const t=debugTraces.get(traceId); if(!t) return;
+    const txt=JSON.stringify(t,null,2);
+    if(global.navigator?.clipboard?.writeText) global.navigator.clipboard.writeText(txt);
+    else {
+      const ta=document.createElement('textarea');
+      ta.value=txt; document.body.appendChild(ta); ta.select();
+      try{ document.execCommand('copy'); }catch{}
+      document.body.removeChild(ta);
+    }
+  }
   global.TraceStore=TraceStore;
   global.debugTraces=new TraceStore();
   global.exportTraceFile=exportTraceFile;
+  global.copyTraceJson=copyTraceJson;
   const _traceMap=new Map();
   function _spanKeyKey(k){ return `${k?.docId||''}:${k?.pageIndex||0}:${k?.fieldKey||''}`; }
   global.traceEvent=function(spanKey, stage, payload={}){


### PR DESCRIPTION
## Summary
- Add standalone trace viewer page with filters for docId, fieldKey, and stage
- Display trace thumbnails with selectable overlays and confidence heatmap
- Introduce copy-to-clipboard utility for trace JSON

## Testing
- `node test/orchestrator.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5c6f49d44832b995991a4a51f0241