### PR TITLE
Add raw data mode to wizard

### DIFF
--- a/invoice-wizard.html
+++ b/invoice-wizard.html
@@ -137,6 +137,12 @@
           </div>
           <div class="field">
             <label style="flex-direction:row;align-items:center;gap:6px;">
+              <input type="checkbox" id="raw-data-toggle" />
+              Raw data mode
+            </label>
+          </div>
+          <div class="field">
+            <label style="flex-direction:row;align-items:center;gap:6px;">
               <input type="checkbox" id="show-raw-toggle" />
               Show raw values
             </label>


### PR DESCRIPTION
## Summary
- add Raw data mode toggle in invoice wizard UI
- honor raw mode in extraction pipeline and columns, skipping all cleaners and fallbacks
- disable raw/clean view toggle when Raw mode is active

## Testing
- `node test/field-map.test.js`
- `node test/orchestrator.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5ceb14f68832b89cf9f45fa1bee37