### PR TITLE
fix: finalize pending selections when overlay unpinned

### DIFF
--- a/invoice-wizard.js
+++ b/invoice-wizard.js
@@ -2125,13 +2125,13 @@ function isOverlayPinned(){
   if(!src || !ov) return false;
   const srcRect = src.getBoundingClientRect();
   const ovRect = ov.getBoundingClientRect();
-  const eps = 1; // css pixel tolerance
+  const eps = 2; // css pixel tolerance
   return Math.abs(srcRect.left - ovRect.left) < eps &&
          Math.abs(srcRect.top - ovRect.top) < eps &&
          Math.abs(srcRect.width - ovRect.width) < eps &&
          Math.abs(srcRect.height - ovRect.height) < eps &&
-         ov.width === src.width &&
-         ov.height === src.height;
+         Math.abs(ov.width - src.width) <= 1 &&
+         Math.abs(ov.height - src.height) <= 1;
 }
 
 function updateOverlayHud(){
@@ -2420,6 +2420,7 @@ async function finalizeSelection(e) {
     state.pendingSelection.endCss = { x: e.clientX - rect.left, y: e.clientY - rect.top };
     state.pendingSelection.active = false;
     drawing = false;
+    syncOverlay();
     return;
   }
   drawing = false;


### PR DESCRIPTION
## Summary
- ensure pending selections finalize by refreshing overlay after pointer release when not pinned
- relax overlay pin tolerance to account for minor size differences

## Testing
- `node test/field-map.test.js`
- `node test/orchestrator.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5d96f87b4832ba69197c05e334b6e