### PR TITLE
Add master DB CSV export

### DIFF
--- a/invoice-wizard.html
+++ b/invoice-wizard.html
@@ -229,6 +229,7 @@
           <div id="fieldsPreview" style="overflow:auto;"></div>
           <pre id="savedJson" class="code"></pre>
           <div class="actions">
+            <button id="exportMasterDbBtn" class="btn">Export Master DB</button>
             <button id="exportBtn" class="btn">Export JSON</button>
             <button id="finishWizardBtn" class="btn">Finish &amp; Return to Dashboard</button>
           </div>
@@ -242,6 +243,7 @@
   </div>
 
   <script src="trace.js"></script>
+  <script src="master-db.js"></script>
   <script src="orchestrator.js"></script>
   <script src="field-map.js"></script>
   <script src="invoice-wizard.js"></script>

--- a/invoice-wizard.js
+++ b/invoice-wizard.js
@@ -90,6 +90,7 @@ const els = {
 
   fieldsPreview:   document.getElementById('fieldsPreview'),
   savedJson:       document.getElementById('savedJson'),
+  exportMasterDbBtn: document.getElementById('exportMasterDbBtn'),
   exportBtn:       document.getElementById('exportBtn'),
   finishWizardBtn: document.getElementById('finishWizardBtn'),
 };
@@ -3182,6 +3183,19 @@ els.exportBtn?.addEventListener('click', ()=>{
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url; a.download = `invoice-schema-${state.username}-${state.docType}.json`;
+  document.body.appendChild(a); a.click(); a.remove();
+  URL.revokeObjectURL(url);
+});
+
+// Export flat Master Database CSV
+els.exportMasterDbBtn?.addEventListener('click', ()=>{
+  const dt = els.dataDocType?.value || state.docType;
+  const db = LS.getDb(state.username, dt);
+  const csv = MasterDB.toCsv(db);
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = `masterdb-${state.username}-${dt}.csv`;
   document.body.appendChild(a); a.click(); a.remove();
   URL.revokeObjectURL(url);
 });

--- a/master-db.js
+++ b/master-db.js
@@ -1,0 +1,94 @@
+(function(root, factory){
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else root.MasterDB = factory();
+})(typeof self !== 'undefined' ? self : this, function(){
+  const HEADERS = [
+    'Store / Business Name',
+    'Department / Division',
+    'Invoice #',
+    'Invoice Date',
+    'Salesperson',
+    'Customer Name',
+    'Customer Address',
+    'Item Code (SKU)',
+    'Item Description',
+    'Quantity',
+    'Unit Price',
+    'Line Total',
+    'Subtotal',
+    'Discount',
+    'Tax Amount',
+    'Invoice Total',
+    'Payment Method',
+    'Payment Status'
+  ];
+
+  function csvEscape(val){
+    if(val === undefined || val === null) return '';
+    const s = String(val);
+    return /[",\n]/.test(s) ? '"' + s.replace(/"/g,'""') + '"' : s;
+  }
+
+  function flatten(db){
+    const rows = [HEADERS];
+    (db||[]).forEach(inv => {
+      const f = inv.fields || {};
+      const invoice = inv.invoice || {};
+      const totals = inv.totals || {};
+      const base = {
+        store: invoice.store || f.store_name?.value || '',
+        dept: f.department_division?.value || '',
+        number: invoice.number || '',
+        date: invoice.salesDateISO || '',
+        salesperson: invoice.salesperson || f.salesperson_rep?.value || '',
+        customer: f.customer_name?.value || '',
+        address: f.customer_address?.value || '',
+        subtotal: totals.subtotal || '',
+        discount: totals.discount || '',
+        tax: totals.tax || '',
+        total: totals.total || '',
+        payMethod: f.payment_method?.value || '',
+        payStatus: f.payment_status?.value || ''
+      };
+      const items = inv.lineItems && inv.lineItems.length ? inv.lineItems : [{}];
+      items.forEach(it => {
+        const qty = it.quantity || '';
+        const unit = it.unit_price || '';
+        let lineTotal = it.amount || '';
+        if(!lineTotal && qty && unit){
+          const q = parseFloat(qty);
+          const u = parseFloat(unit);
+          if(!isNaN(q) && !isNaN(u)) lineTotal = (q*u).toFixed(2);
+        }
+        const discount = it.discount !== undefined ? it.discount : base.discount;
+        rows.push([
+          base.store,
+          base.dept,
+          base.number,
+          base.date,
+          base.salesperson,
+          base.customer,
+          base.address,
+          it.sku || '',
+          it.description || '',
+          qty,
+          unit,
+          lineTotal || '',
+          base.subtotal,
+          discount || '',
+          base.tax,
+          base.total,
+          base.payMethod,
+          base.payStatus
+        ]);
+      });
+    });
+    return rows;
+  }
+
+  function toCsv(db){
+    return flatten(db).map(r => r.map(csvEscape).join(',')).join('\n');
+  }
+
+  return { HEADERS, flatten, toCsv };
+});

--- a/test/master-db.test.js
+++ b/test/master-db.test.js
@@ -1,0 +1,43 @@
+const assert = require('assert');
+const MasterDB = require('../master-db.js');
+
+const sampleDb = [{
+  invoice: {
+    number: 'INV001',
+    salesDateISO: '2024-01-05',
+    salesperson: 'Alice',
+    store: 'My Store'
+  },
+  fields: {
+    department_division: { value: 'Electronics' },
+    customer_name: { value: 'Bob' },
+    customer_address: { value: '123 Main St' },
+    payment_method: { value: 'Credit Card' },
+    payment_status: { value: 'Paid' }
+  },
+  totals: {
+    subtotal: '100.00',
+    tax: '13.00',
+    total: '113.00',
+    discount: '5.00'
+  },
+  lineItems: [
+    { sku: 'SKU1', description: 'Item One', quantity: '2', unit_price: '20.00', amount: '40.00' },
+    { sku: 'SKU2', description: 'Item Two', quantity: '1', unit_price: '60.00' }
+  ]
+}];
+
+const rows = MasterDB.flatten(sampleDb);
+assert.deepStrictEqual(rows[0], MasterDB.HEADERS);
+assert.strictEqual(rows.length, 3);
+assert.strictEqual(rows[1][0], 'My Store');
+assert.strictEqual(rows[1][7], 'SKU1');
+assert.strictEqual(rows[2][7], 'SKU2');
+assert.strictEqual(rows[2][11], '60.00'); // computed line total
+assert.strictEqual(rows[1][12], '100.00'); // subtotal repeated
+
+const csv = MasterDB.toCsv(sampleDb);
+assert.ok(csv.startsWith('Store / Business Name'));
+assert.ok(csv.split('\n').length === 3);
+
+console.log('MasterDB tests passed.');


### PR DESCRIPTION
## Summary
- implement MasterDB module that flattens wizard results and generates CSV with standardized invoice headers
- expose "Export Master DB" button and wiring in the invoice wizard UI
- cover CSV generation with unit tests

## Testing
- `node test/field-map.test.js`
- `node test/orchestrator.test.js`
- `node test/master-db.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6eced144c832ba60d8655ac709dd1