### PR TITLE
Fix MasterDB to export one row per line item

### DIFF
--- a/master-db.js
+++ b/master-db.js
@@ -74,12 +74,12 @@
       };
       let items = Array.isArray(inv.lineItems) && inv.lineItems.length ? inv.lineItems : null;
       if(!items){
-        const codes = normalizeArray(inv.item_code);
-        const descs = normalizeArray(inv.item_description);
+        const codes = normalizeArray(inv.item_code || inv.sku);
+        const descs = normalizeArray(inv.item_description || inv.product_description);
         const qtys = normalizeArray(inv.qty || inv.quantity);
         const units = normalizeArray(inv.unit_price);
         const totals = normalizeArray(inv.line_total);
-        const lineNos = normalizeArray(inv.line_number);
+        const lineNos = normalizeArray(inv.line_number || inv.line_no);
         let N = lineNos.length;
         if(!N){
           const lens = [codes,descs,qtys,units,totals].filter(a=>a.length).map(a=>a.length);

--- a/test/master-db.test.js
+++ b/test/master-db.test.js
@@ -62,4 +62,16 @@ assert.strictEqual(rows2[1][7], 'A1');
 assert.strictEqual(rows2[2][7], 'B2');
 assert.strictEqual(rows2[2][18], '2');
 
+const altFieldsDb = [{
+  invoice: { number: 'INV003', salesDateISO: '2024-03-01' },
+  sku: ['S1', 'S2'],
+  product_description: ['Thing 1', 'Thing 2'],
+  line_number: ['001', '002']
+}];
+const rows3 = MasterDB.flatten(altFieldsDb);
+assert.strictEqual(rows3.length, 3);
+assert.strictEqual(rows3[1][7], 'S1');
+assert.strictEqual(rows3[2][8], 'Thing 2');
+assert.strictEqual(rows3[2][18], '002');
+
 console.log('MasterDB tests passed.');


### PR DESCRIPTION
## Summary
- allow MasterDB to recognize `sku`, `product_description`, and `line_no` fields when flattening invoices
- cover alternate line-item field names with new test

## Testing
- `node test/master-db.test.js`
- `node test/field-map.test.js`
- `node test/orchestrator.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c725aba580832ba81fd5c741018fae