### PR TITLE
Fix MasterDB export to retain line items and clean cells

### DIFF
--- a/master-db.js
+++ b/master-db.js
@@ -32,6 +32,11 @@
     return num.toFixed(opts.fixed);
   }
 
+  function cleanCell(val){
+    if(val === undefined || val === null) return '';
+    return String(val).replace(/\s+/g,' ').trim();
+  }
+
   function csvEscape(val){
     if(val === undefined || val === null) return '';
     const s = String(val);
@@ -58,19 +63,19 @@
       const invoice = inv.invoice || {};
       const totals = inv.totals || {};
       const base = {
-        store: invoice.store || f.store_name?.value || '',
-        dept: f.department_division?.value || '',
-        number: invoice.number || '',
-        date: invoice.salesDateISO || '',
-        salesperson: invoice.salesperson || f.salesperson_rep?.value || '',
-        customer: f.customer_name?.value || '',
-        address: f.customer_address?.value || '',
+        store: cleanCell(invoice.store || f.store_name?.value || ''),
+        dept: cleanCell(f.department_division?.value || ''),
+        number: cleanCell(invoice.number || ''),
+        date: cleanCell(invoice.salesDateISO || ''),
+        salesperson: cleanCell(invoice.salesperson || f.salesperson_rep?.value || ''),
+        customer: cleanCell(f.customer_name?.value || ''),
+        address: cleanCell(f.customer_address?.value || ''),
         subtotal: cleanNumber(totals.subtotal, {fixed:2}),
         discount: cleanNumber(totals.discount, {fixed:2}),
         tax: cleanNumber(totals.tax, {fixed:2}),
         total: cleanNumber(totals.total, {fixed:2}),
-        payMethod: f.payment_method?.value || '',
-        payStatus: f.payment_status?.value || ''
+        payMethod: cleanCell(f.payment_method?.value || ''),
+        payStatus: cleanCell(f.payment_status?.value || '')
       };
       let items = Array.isArray(inv.lineItems) && inv.lineItems.length ? inv.lineItems : null;
       if(!items){
@@ -113,8 +118,8 @@
           base.salesperson,
           base.customer,
           base.address,
-          it.sku || '',
-          it.description || '',
+          cleanCell(it.sku || ''),
+          cleanCell(it.description || ''),
           qty,
           unit,
           lineTotal || '',

--- a/test/master-db.test.js
+++ b/test/master-db.test.js
@@ -74,4 +74,35 @@ assert.strictEqual(rows3[1][7], 'S1');
 assert.strictEqual(rows3[2][8], 'Thing 2');
 assert.strictEqual(rows3[2][18], '002');
 
+const messyDb = [{
+  invoice: {
+    number: ' INV004 ',
+    salesDateISO: '2024-04-01\n',
+    salesperson: '  Jane Doe  ',
+    store: 'STORE\nNAME'
+  },
+  fields: {
+    department_division: { value: 'North\nRegion' },
+    customer_name: { value: 'Customer\nName' },
+    customer_address: { value: '50 CLUB\nPISCINE NEPEAN' },
+    payment_method: { value: 'Pay\nLater' },
+    payment_status: { value: 'Paid\n' }
+  },
+  lineItems: [
+    { sku: ' 001 ', description: 'Widget\nLarge', quantity: '2', unit_price: '5', amount: '10' }
+  ]
+}];
+const messyRows = MasterDB.flatten(messyDb);
+assert.strictEqual(messyRows.length, 2);
+assert.strictEqual(messyRows[1][0], 'STORE NAME');
+assert.strictEqual(messyRows[1][1], 'North Region');
+assert.strictEqual(messyRows[1][2], 'INV004');
+assert.strictEqual(messyRows[1][3], '2024-04-01');
+assert.strictEqual(messyRows[1][5], 'Customer Name');
+assert.strictEqual(messyRows[1][6], '50 CLUB PISCINE NEPEAN');
+assert.strictEqual(messyRows[1][7], '001');
+assert.strictEqual(messyRows[1][8], 'Widget Large');
+assert.strictEqual(messyRows[1][16], 'Pay Later');
+assert.ok(!/\n/.test(messyRows[1].join('')));
+
 console.log('MasterDB tests passed.');


### PR DESCRIPTION
## Summary
- prevent compileDocument from dropping previously extracted line items by reusing the current capture or stored rows
- normalize invoice header strings when persisting records and when flattening for MasterDB CSV
- ensure MasterDB export cells are single-line strings and add regression coverage for the cleanup

## Testing
- node test/master-db.test.js
- node test/orchestrator.test.js
- node test/field-map.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c86e65da28832b836c70b2d972e95a