### PR TITLE
Bind MasterDB export to saved fields SSOT

### DIFF
--- a/master-db.js
+++ b/master-db.js
@@ -24,37 +24,61 @@
     'Line No'
   ];
 
-  const ITEM_FIELD_ALIASES = {
-    sku: ['sku', 'SKU', 'item_code', 'itemCode', 'code', 'Code', 'product_code', 'productCode', 'item_sku', 'itemSku'],
-    description: ['description', 'Description', 'item_description', 'itemDescription', 'product_description', 'productDescription', 'desc', 'Desc', 'name', 'Name', 'item_name', 'itemName'],
-    quantity: ['quantity', 'Quantity', 'qty', 'Qty', 'qty_sold', 'qtySold', 'units', 'Units', 'unit_qty', 'unitQty', 'count', 'Count'],
-    unit_price: ['unit_price', 'unitPrice', 'price', 'Price', 'unit_cost', 'unitCost', 'cost', 'Cost', 'unit', 'Unit'],
-    amount: ['amount', 'Amount', 'line_total', 'lineTotal', 'total', 'Total', 'extended_price', 'extendedPrice', 'extension', 'Extension', 'line_amount', 'lineAmount'],
-    discount: ['discount', 'Discount', 'line_discount', 'lineDiscount', 'disc', 'Disc', 'item_discount', 'itemDiscount'],
-    line_no: ['line_no', 'lineNo', 'line_number', 'lineNumber', 'lineno', 'LineNo', 'line', 'Line', 'seq', 'Seq', 'position', 'Position']
-  };
-
-  const COLUMN_ALIASES = {
-    sku: ['item_code', 'itemCode', 'sku', 'SKU', 'sku_col', 'skuCol', 'code', 'Code', 'product_code', 'productCode'],
-    description: ['item_description', 'itemDescription', 'product_description', 'productDescription', 'description', 'Description', 'desc', 'Desc', 'item_desc', 'itemDesc'],
-    quantity: ['qty', 'Qty', 'quantity', 'Quantity', 'qty_col', 'qtyCol', 'quantity_col', 'quantityCol', 'units', 'Units'],
-    unit_price: ['unit_price', 'unitPrice', 'price', 'Price', 'unit_price_col', 'unitPriceCol', 'unit_cost', 'unitCost', 'cost', 'Cost'],
-    amount: ['line_total', 'lineTotal', 'amount', 'Amount', 'line_amount', 'lineAmount', 'extended_price', 'extendedPrice', 'extension', 'Extension'],
-    discount: ['discount', 'Discount', 'line_discount', 'lineDiscount', 'item_discount', 'itemDiscount'],
-    line_no: ['line_number', 'lineNumber', 'line_no', 'lineNo', 'lineno', 'LineNo', 'seq', 'Seq']
-  };
-
-  function cleanNumber(val, opts={}){
-    if(val === undefined || val === null || val === '') return '';
-    const num = parseFloat(String(val).replace(/,/g,''));
-    if(!isFinite(num)) return '';
-    if(opts.fixed === undefined) return String(num);
-    return num.toFixed(opts.fixed);
+  function cleanText(value){
+    if(value === undefined || value === null) return '';
+    return String(value).replace(/\s+/g, ' ').trim();
   }
 
-  function cleanCell(val){
-    if(val === undefined || val === null) return '';
-    return String(val).replace(/\s+/g,' ').trim();
+  function cleanNumeric(value){
+    if(value === undefined || value === null) return '';
+    const compact = String(value).replace(/\s+/g, '').replace(/,/g, '');
+    if(!compact) return '';
+    const normalized = compact.replace(/[^0-9.-]/g, '');
+    if(!normalized || /^-?\.?$/.test(normalized)) return '';
+    const num = Number(normalized);
+    if(!isFinite(num)) return '';
+    return num.toFixed(2);
+  }
+
+  const cleanSku = cleanText;
+  const cleanDescription = cleanText;
+  const cleanLineNo = cleanText;
+
+  function extractFieldValue(record, key){
+    const field = record?.fields?.[key];
+    if(field && typeof field === 'object' && 'value' in field) return field.value;
+    return field ?? '';
+  }
+
+  function buildInvoiceCells(record){
+    return {
+      store: cleanText(extractFieldValue(record, 'store_name')),
+      dept: cleanText(extractFieldValue(record, 'department_division')),
+      number: cleanText(extractFieldValue(record, 'invoice_number')),
+      date: cleanText(extractFieldValue(record, 'invoice_date')),
+      salesperson: cleanText(extractFieldValue(record, 'salesperson_rep')),
+      customer: cleanText(extractFieldValue(record, 'customer_name')),
+      address: cleanText(extractFieldValue(record, 'customer_address')),
+      subtotal: cleanNumeric(extractFieldValue(record, 'subtotal_amount')),
+      discount: cleanNumeric(extractFieldValue(record, 'discounts_amount')),
+      tax: cleanNumeric(extractFieldValue(record, 'tax_amount')),
+      total: cleanNumeric(extractFieldValue(record, 'invoice_total')),
+      paymentMethod: cleanText(extractFieldValue(record, 'payment_method')),
+      paymentStatus: cleanText(extractFieldValue(record, 'payment_status'))
+    };
+  }
+
+  function prepareItems(record){
+    if(!record || !Array.isArray(record.lineItems)) return [];
+    return record.lineItems.map(item => ({
+      original: item,
+      sku: cleanSku(item?.sku),
+      description: cleanDescription(item?.description),
+      quantity: cleanNumeric(item?.quantity),
+      unitPrice: cleanNumeric(item?.unit_price),
+      amount: cleanNumeric(item?.amount),
+      lineNo: cleanLineNo(item?.line_no)
+    }));
   }
 
   function csvEscape(val){
@@ -63,219 +87,81 @@
     return /[",\n]/.test(s) ? '"' + s.replace(/"/g,'""') + '"' : s;
   }
 
-  function normalizeArray(val){
-    if(Array.isArray(val)){
-      if(val.length === 1 && typeof val[0] === 'string' && /\n/.test(val[0])){
-        return val[0].split(/\r?\n/).map(s=>s.trim()).filter(Boolean);
-      }
-      return val;
-    }
-    if(typeof val === 'string'){
-      return val.split(/\r?\n/).map(s=>s.trim()).filter(Boolean);
-    }
-    if(typeof val === 'number'){
-      return [val];
-    }
-    return [];
-  }
+  function flatten(ssot){
+    const records = Array.isArray(ssot) ? ssot.filter(Boolean) : ssot ? [ssot] : [];
+    const prepared = records.map(record => ({
+      record,
+      invoice: buildInvoiceCells(record),
+      items: prepareItems(record)
+    }));
 
-  function pickField(obj, aliases){
-    if(!obj || typeof obj !== 'object') return undefined;
-    for(const key of aliases){
-      if(!Object.prototype.hasOwnProperty.call(obj, key)) continue;
-      let val = obj[key];
-      if(val && typeof val === 'object' && !Array.isArray(val) && 'value' in val){
-        val = val.value;
-      }
-      if(val === undefined || val === null) continue;
-      if(typeof val === 'number'){
-        if(!isFinite(val)) continue;
-        return val;
-      }
-      if(typeof val === 'string'){
-        const trimmed = val.trim();
-        if(trimmed === '') continue;
-        return trimmed;
-      }
-      const str = String(val).trim();
-      if(str !== '') return val;
-    }
-    return undefined;
-  }
+    const allItems = prepared.flatMap(r => r.items);
 
-  function hasItemData(row){
-    return ['sku','description','quantity','unit_price','amount'].some(key => {
-      const val = row[key];
-      if(val === undefined || val === null) return false;
-      if(typeof val === 'number') return isFinite(val);
-      return String(val).trim() !== '';
+    const counts = {
+      sku_count: allItems.filter(it => it.sku !== '').length,
+      qty_count: allItems.filter(it => it.quantity !== '').length,
+      price_count: allItems.filter(it => it.unitPrice !== '').length,
+      line_no_count: allItems.filter(it => it.lineNo !== '').length
+    };
+
+    const firstItem = allItems[0]?.original || null;
+    const lastItem = allItems.length ? allItems[allItems.length-1].original : null;
+    console.log('[MasterDB] integrity', { ...counts, first_item: firstItem, last_item: lastItem });
+
+    if(counts.sku_count === 0){
+      throw new Error('Exporter input empty—SSOT not wired.');
+    }
+
+    const missing = { sku: [], quantity: [], unit_price: [], line_no: [] };
+    allItems.forEach((item, idx) => {
+      if(item.sku === '') missing.sku.push(idx + 1);
+      if(item.quantity === '') missing.quantity.push(idx + 1);
+      if(item.unitPrice === '') missing.unit_price.push(idx + 1);
+      if(item.lineNo === '') missing.line_no.push(idx + 1);
     });
-  }
-
-  function normalizeItemObject(raw, idx){
-    if(raw === undefined || raw === null) return null;
-    let obj = raw;
-    if(typeof obj !== 'object' || Array.isArray(obj)){
-      obj = { description: obj };
+    if(missing.sku.length || missing.quantity.length || missing.unit_price.length || missing.line_no.length){
+      console.warn('[MasterDB] count mismatch', { counts, missing });
     }
-    const row = {
-      sku: pickField(obj, ITEM_FIELD_ALIASES.sku),
-      description: pickField(obj, ITEM_FIELD_ALIASES.description),
-      quantity: pickField(obj, ITEM_FIELD_ALIASES.quantity),
-      unit_price: pickField(obj, ITEM_FIELD_ALIASES.unit_price),
-      amount: pickField(obj, ITEM_FIELD_ALIASES.amount)
-    };
-    const disc = pickField(obj, ITEM_FIELD_ALIASES.discount);
-    if(disc !== undefined) row.discount = disc;
-    const providedLine = pickField(obj, ITEM_FIELD_ALIASES.line_no);
-    row.line_no = providedLine !== undefined ? providedLine : (idx + 1);
-    if(!hasItemData(row)) return null;
-    return row;
-  }
 
-  function itemsFromArray(src){
-    if(!Array.isArray(src)) return [];
-    return src.map((it, idx) => normalizeItemObject(it, idx)).filter(Boolean);
-  }
-
-  function columnValues(source, aliases){
-    if(!source || typeof source !== 'object') return [];
-    for(const key of aliases){
-      if(!Object.prototype.hasOwnProperty.call(source, key)) continue;
-      const arr = normalizeArray(source[key]);
-      if(arr.length) return arr;
-    }
-    return [];
-  }
-
-  function itemsFromColumns(source){
-    if(!source || typeof source !== 'object' || Array.isArray(source)) return [];
-    const cols = {
-      sku: columnValues(source, COLUMN_ALIASES.sku),
-      description: columnValues(source, COLUMN_ALIASES.description),
-      quantity: columnValues(source, COLUMN_ALIASES.quantity),
-      unit_price: columnValues(source, COLUMN_ALIASES.unit_price),
-      amount: columnValues(source, COLUMN_ALIASES.amount),
-      discount: columnValues(source, COLUMN_ALIASES.discount),
-      line_no: columnValues(source, COLUMN_ALIASES.line_no)
-    };
-    const lengths = Object.values(cols).map(list => list.length).filter(len => len > 0);
-    const N = lengths.length ? Math.max(...lengths) : 0;
-    if(!N) return [];
-    const rows = [];
-    for(let i=0;i<N;i++){
-      const candidate = {};
-      if(i < cols.sku.length) candidate.sku = cols.sku[i];
-      if(i < cols.description.length) candidate.description = cols.description[i];
-      if(i < cols.quantity.length) candidate.quantity = cols.quantity[i];
-      if(i < cols.unit_price.length) candidate.unit_price = cols.unit_price[i];
-      if(i < cols.amount.length) candidate.amount = cols.amount[i];
-      if(i < cols.discount.length) candidate.discount = cols.discount[i];
-      if(i < cols.line_no.length) candidate.line_no = cols.line_no[i];
-      const norm = normalizeItemObject(candidate, rows.length);
-      if(norm) rows.push(norm);
-    }
-    return rows;
-  }
-
-  function flatten(db){
     const rows = [HEADERS];
-    (db||[]).forEach(inv => {
-      const f = inv.fields || {};
-      const invoice = inv.invoice || {};
-      const totals = inv.totals || {};
-      const base = {
-        store: cleanCell(invoice.store || f.store_name?.value || ''),
-        dept: cleanCell(f.department_division?.value || ''),
-        number: cleanCell(invoice.number || ''),
-        date: cleanCell(invoice.salesDateISO || ''),
-        salesperson: cleanCell(invoice.salesperson || f.salesperson_rep?.value || ''),
-        customer: cleanCell(f.customer_name?.value || ''),
-        address: cleanCell(f.customer_address?.value || ''),
-        subtotal: cleanNumber(totals.subtotal, {fixed:2}),
-        discount: cleanNumber(totals.discount, {fixed:2}),
-        tax: cleanNumber(totals.tax, {fixed:2}),
-        total: cleanNumber(totals.total, {fixed:2}),
-        payMethod: cleanCell(f.payment_method?.value || ''),
-        payStatus: cleanCell(f.payment_status?.value || '')
-      };
-      let items = [];
-      const arraySources = [inv.lineItems, inv.line_items, inv.items, inv.products];
-      for(const src of arraySources){
-        items = itemsFromArray(src);
-        if(items.length) break;
-      }
-      if(!items.length){
-        const columnSources = [inv, inv.lineItems, inv.line_items];
-        for(const src of columnSources){
-          items = itemsFromColumns(src);
-          if(items.length) break;
+    prepared.forEach(({ invoice, items }) => {
+      items.forEach((item, idx) => {
+        let lineTotal = item.amount;
+        if(lineTotal === '' && item.quantity && item.unitPrice){
+          const q = parseFloat(item.quantity);
+          const u = parseFloat(item.unitPrice);
+          if(!isNaN(q) && !isNaN(u)) lineTotal = (q * u).toFixed(2);
         }
-      }
-      if(!items.length){
-        const codes = normalizeArray(inv.item_code || inv.sku);
-        const descs = normalizeArray(inv.item_description || inv.product_description);
-        const qtys = normalizeArray(inv.qty || inv.quantity);
-        const units = normalizeArray(inv.unit_price);
-        const totals = normalizeArray(inv.line_total);
-        const lineNos = normalizeArray(inv.line_number || inv.line_no);
-        const discounts = normalizeArray(inv.line_discount || inv.discount);
-        const lengths = [codes.length, descs.length, qtys.length, units.length, totals.length, lineNos.length, discounts.length].filter(len => len > 0);
-        const N = lengths.length ? Math.max(...lengths) : 0;
-        if(N){
-          items = Array.from({length:N}).map((_,i)=>{
-            const candidate = {
-              sku: codes[i],
-              description: descs[i],
-              quantity: qtys[i],
-              unit_price: units[i],
-              amount: totals[i],
-              line_no: lineNos[i],
-              discount: discounts[i]
-            };
-            return normalizeItemObject(candidate, i);
-          }).filter(Boolean);
-        }
-      }
-      items = items.map((it, idx) => ({ ...it, line_no: it.line_no !== undefined ? it.line_no : (idx + 1) }));
-      items.forEach((it, idx) => {
-        const qty = cleanNumber(it.quantity, {});
-        const unit = cleanNumber(it.unit_price, {fixed:2});
-        let lineTotal = cleanNumber(it.amount, {fixed:2});
-        if(!lineTotal && qty && unit){
-          const q = parseFloat(qty);
-          const u = parseFloat(unit);
-          if(!isNaN(q) && !isNaN(u)) lineTotal = (q*u).toFixed(2);
-        }
-        const discount = it.discount !== undefined ? cleanNumber(it.discount,{fixed:2}) : base.discount;
+        const lineNo = item.lineNo || String(idx + 1);
         rows.push([
-          base.store,
-          base.dept,
-          base.number,
-          base.date,
-          base.salesperson,
-          base.customer,
-          base.address,
-          cleanCell(it.sku || ''),
-          cleanCell(it.description || ''),
-          qty,
-          unit,
-          lineTotal || '',
-          base.subtotal,
-          discount || '',
-          base.tax,
-          base.total,
-          base.payMethod,
-          base.payStatus,
-          String(it.line_no !== undefined ? it.line_no : (idx+1))
+          invoice.store,
+          invoice.dept,
+          invoice.number,
+          invoice.date,
+          invoice.salesperson,
+          invoice.customer,
+          invoice.address,
+          item.sku,
+          item.description,
+          item.quantity,
+          item.unitPrice,
+          lineTotal,
+          invoice.subtotal,
+          invoice.discount,
+          invoice.tax,
+          invoice.total,
+          invoice.paymentMethod,
+          invoice.paymentStatus,
+          lineNo
         ]);
       });
     });
+
     return rows;
   }
 
-  function toCsv(db){
-    return flatten(db).map(r => r.map(csvEscape).join(',')).join('\n');
+  function toCsv(ssot){
+    return flatten(ssot).map(r => r.map(csvEscape).join(',')).join('\n');
   }
 
   return { HEADERS, flatten, toCsv };

--- a/test/master-db.test.js
+++ b/test/master-db.test.js
@@ -1,128 +1,63 @@
 const assert = require('assert');
 const MasterDB = require('../master-db.js');
 
-const sampleDb = [{
-  invoice: {
-    number: 'INV001',
-    salesDateISO: '2024-01-05',
-    salesperson: 'Alice',
-    store: 'My Store'
-  },
+const ssot = {
   fields: {
-    department_division: { value: 'Electronics' },
-    customer_name: { value: 'Bob' },
-    customer_address: { value: '123 Main St' },
-    payment_method: { value: 'Credit Card' },
+    store_name: { value: ' My Store ' },
+    department_division: { value: 'Electronics\nDivision' },
+    invoice_number: { value: 'INV-001 ' },
+    invoice_date: { value: '2024-01-05' },
+    salesperson_rep: { value: ' Alice Smith ' },
+    customer_name: { value: 'Bob Buyer' },
+    customer_address: { value: '123 Main St\nSuite 5' },
+    subtotal_amount: { value: '1050' },
+    discounts_amount: { value: '10.5' },
+    tax_amount: { value: '135.75' },
+    invoice_total: { value: '1175.25' },
+    payment_method: { value: 'Credit\nCard' },
     payment_status: { value: 'Paid' }
   },
-  totals: {
-    subtotal: '1,240.00',
-    tax: '161.20',
-    total: '1,401.20',
-    discount: '5.00'
-  },
   lineItems: [
-    { sku: 'SKU1', description: 'Item One', quantity: '2', unit_price: '20.00', amount: '40.00' },
-    { sku: 'SKU2', description: 'Item Two', quantity: '1', unit_price: '1,200.00' }
+    { sku: '0001', description: 'Widget A\nLarge', quantity: '2', unit_price: '100.5', amount: '201', line_no: '0001' },
+    { sku: '0002', description: 'Widget B', quantity: '3', unit_price: '50', amount: '', line_no: ' ' }
   ]
-}];
+};
 
-const rows = MasterDB.flatten(sampleDb);
+const rows = MasterDB.flatten(ssot);
 assert.deepStrictEqual(rows[0], MasterDB.HEADERS);
 assert.strictEqual(rows.length, 3);
 assert.strictEqual(rows[1][0], 'My Store');
-assert.strictEqual(rows[1][18], '1');
+assert.strictEqual(rows[1][1], 'Electronics Division');
+assert.strictEqual(rows[1][2], 'INV-001');
+assert.strictEqual(rows[1][3], '2024-01-05');
+assert.strictEqual(rows[1][4], 'Alice Smith');
+assert.strictEqual(rows[1][6], '123 Main St Suite 5');
+assert.strictEqual(rows[1][7], '0001');
+assert.strictEqual(rows[1][8], 'Widget A Large');
+assert.strictEqual(rows[1][9], '2.00');
+assert.strictEqual(rows[1][10], '100.50');
+assert.strictEqual(rows[1][11], '201.00');
+assert.strictEqual(rows[1][12], '1050.00');
+assert.strictEqual(rows[1][13], '10.50');
+assert.strictEqual(rows[1][14], '135.75');
+assert.strictEqual(rows[1][15], '1175.25');
+assert.strictEqual(rows[1][16], 'Credit Card');
+assert.strictEqual(rows[1][17], 'Paid');
+assert.strictEqual(rows[1][18], '0001');
+
+assert.strictEqual(rows[2][7], '0002');
+assert.strictEqual(rows[2][9], '3.00');
+assert.strictEqual(rows[2][10], '50.00');
+assert.strictEqual(rows[2][11], '150.00');
 assert.strictEqual(rows[2][18], '2');
-assert.strictEqual(rows[1][7], 'SKU1');
-assert.strictEqual(rows[2][7], 'SKU2');
-assert.strictEqual(rows[2][10], '1200.00'); // cleaned unit price
-assert.strictEqual(rows[2][11], '1200.00'); // computed line total
-assert.strictEqual(rows[1][12], '1240.00'); // subtotal repeated
 
-const misaligned = MasterDB.flatten([{ item_code: ['A'], item_description: ['B', 'C'], qty: ['1'], unit_price: ['10'] }]);
-assert.strictEqual(misaligned.length, 3);
-assert.strictEqual(misaligned[1][7], 'A');
-assert.strictEqual(misaligned[1][8], 'B');
-assert.strictEqual(misaligned[2][8], 'C');
-assert.strictEqual(misaligned[1][18], '1');
-assert.strictEqual(misaligned[2][18], '2');
+assert.strictEqual(ssot.lineItems[1].line_no, ' ');
 
-const csv = MasterDB.toCsv(sampleDb);
-assert.ok(csv.startsWith('Store / Business Name'));
-assert.ok(csv.split('\n').length === 3);
+const csv1 = MasterDB.toCsv(ssot);
+const csv2 = MasterDB.toCsv(ssot);
+assert.strictEqual(csv1, csv2);
+assert.strictEqual(csv1.split('\n').length, rows.length);
 
-const textDb = [{
-  invoice: { number: 'INV002', salesDateISO: '2024-02-10' },
-  item_code: ['A1\nB2'],
-  item_description: ['First item\nSecond item'],
-  qty: ['1\n2'],
-  unit_price: ['10\n20'],
-  line_number: ['1\n2']
-}];
-const rows2 = MasterDB.flatten(textDb);
-assert.strictEqual(rows2.length, 3);
-assert.strictEqual(rows2[1][7], 'A1');
-assert.strictEqual(rows2[2][7], 'B2');
-assert.strictEqual(rows2[2][18], '2');
-
-const altFieldsDb = [{
-  invoice: { number: 'INV003', salesDateISO: '2024-03-01' },
-  sku: ['S1', 'S2'],
-  product_description: ['Thing 1', 'Thing 2'],
-  line_number: ['001', '002']
-}];
-const rows3 = MasterDB.flatten(altFieldsDb);
-assert.strictEqual(rows3.length, 3);
-assert.strictEqual(rows3[1][7], 'S1');
-assert.strictEqual(rows3[2][8], 'Thing 2');
-assert.strictEqual(rows3[2][18], '002');
-
-const columnObjectDb = [{
-  invoice: { number: 'INV004', salesDateISO: '2024-03-02' },
-  lineItems: {
-    item_code: ['C1', 'C2', 'C3'],
-    item_description: ['First', 'Second', 'Third'],
-    qty: ['1', '2', '3'],
-    unit_price: ['5', '6', '7'],
-    line_total: ['5', '12', '21']
-  }
-}];
-const rows4 = MasterDB.flatten(columnObjectDb);
-assert.strictEqual(rows4.length, 4);
-assert.strictEqual(rows4[1][7], 'C1');
-assert.strictEqual(rows4[3][8], 'Third');
-assert.strictEqual(rows4[3][11], '21.00');
-assert.strictEqual(rows4[2][18], '2');
-
-const messyDb = [{
-  invoice: {
-    number: ' INV004 ',
-    salesDateISO: '2024-04-01\n',
-    salesperson: '  Jane Doe  ',
-    store: 'STORE\nNAME'
-  },
-  fields: {
-    department_division: { value: 'North\nRegion' },
-    customer_name: { value: 'Customer\nName' },
-    customer_address: { value: '50 CLUB\nPISCINE NEPEAN' },
-    payment_method: { value: 'Pay\nLater' },
-    payment_status: { value: 'Paid\n' }
-  },
-  lineItems: [
-    { sku: ' 001 ', description: 'Widget\nLarge', quantity: '2', unit_price: '5', amount: '10' }
-  ]
-}];
-const messyRows = MasterDB.flatten(messyDb);
-assert.strictEqual(messyRows.length, 2);
-assert.strictEqual(messyRows[1][0], 'STORE NAME');
-assert.strictEqual(messyRows[1][1], 'North Region');
-assert.strictEqual(messyRows[1][2], 'INV004');
-assert.strictEqual(messyRows[1][3], '2024-04-01');
-assert.strictEqual(messyRows[1][5], 'Customer Name');
-assert.strictEqual(messyRows[1][6], '50 CLUB PISCINE NEPEAN');
-assert.strictEqual(messyRows[1][7], '001');
-assert.strictEqual(messyRows[1][8], 'Widget Large');
-assert.strictEqual(messyRows[1][16], 'Pay Later');
-assert.ok(!/\n/.test(messyRows[1].join('')));
+assert.throws(() => MasterDB.toCsv({ fields: {}, lineItems: [] }), /Exporter input empty—SSOT not wired./);
 
 console.log('MasterDB tests passed.');


### PR DESCRIPTION
## Summary
- capture the saved fields SSOT record in wizard state and feed it directly into the MasterDB exporter
- rebuild the MasterDB exporter to consume that SSOT object, clean values, log integrity counts, and drop legacy fallbacks
- refresh the MasterDB unit test to reflect the new SSOT-driven export behavior

## Testing
- node test/master-db.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c88240ce6c832b9184a9d3b9d8c92f