### PR TITLE
Add missing-cell export and structured MasterDB output

### DIFF
--- a/invoice-wizard.html
+++ b/invoice-wizard.html
@@ -230,6 +230,7 @@
           <pre id="savedJson" class="code"></pre>
           <div class="actions">
             <button id="exportMasterDbBtn" class="btn">Export Master DB</button>
+            <button id="exportMissingBtn" class="btn">Export Missing Cells</button>
             <button id="exportBtn" class="btn">Export JSON</button>
             <button id="finishWizardBtn" class="btn">Finish &amp; Return to Dashboard</button>
           </div>

--- a/invoice-wizard.js
+++ b/invoice-wizard.js
@@ -91,6 +91,7 @@ const els = {
   fieldsPreview:   document.getElementById('fieldsPreview'),
   savedJson:       document.getElementById('savedJson'),
   exportMasterDbBtn: document.getElementById('exportMasterDbBtn'),
+  exportMissingBtn: document.getElementById('exportMissingBtn'),
   exportBtn:       document.getElementById('exportBtn'),
   finishWizardBtn: document.getElementById('finishWizardBtn'),
 };
@@ -4050,6 +4051,22 @@ els.exportMasterDbBtn?.addEventListener('click', ()=>{
   } catch(err){
     console.error('MasterDB export failed', err);
     alert(err?.message || 'Failed to export MasterDB CSV');
+  }
+});
+els.exportMissingBtn?.addEventListener('click', ()=>{
+  const dt = els.dataDocType?.value || state.docType;
+  try {
+    const { missingMap } = MasterDB.flatten(state.savedFieldsRecord);
+    const json = JSON.stringify(missingMap, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = `masterdb-missing-${state.username}-${dt}.json`;
+    document.body.appendChild(a); a.click(); a.remove();
+    URL.revokeObjectURL(url);
+  } catch(err){
+    console.error('Missing cell export failed', err);
+    alert(err?.message || 'Failed to export missing-cell diagnostics');
   }
 });
 els.finishWizardBtn?.addEventListener('click', ()=>{

--- a/test/master-db.test.js
+++ b/test/master-db.test.js
@@ -19,11 +19,11 @@ const ssot = {
   },
   lineItems: [
     { sku: '0001', description: 'Widget A\nLarge', quantity: '2', unit_price: '100.5', amount: '201', line_no: '0001' },
-    { sku: '0002', description: 'Widget B', quantity: '3', unit_price: '50', amount: '', line_no: ' ' }
+    { sku: '0002', description: 'Widget B', quantity: '3', unit_price: '50', amount: '', line_no: ' ', __missing: { line_no: true } }
   ]
 };
 
-const rows = MasterDB.flatten(ssot);
+const { rows, missingMap } = MasterDB.flatten(ssot);
 assert.deepStrictEqual(rows[0], MasterDB.HEADERS);
 assert.strictEqual(rows.length, 3);
 assert.strictEqual(rows[1][0], 'My Store');
@@ -50,6 +50,19 @@ assert.strictEqual(rows[2][9], '3.00');
 assert.strictEqual(rows[2][10], '50.00');
 assert.strictEqual(rows[2][11], '150.00');
 assert.strictEqual(rows[2][18], '2');
+
+assert.deepStrictEqual(missingMap.summary, {
+  sku: [],
+  quantity: [],
+  unit_price: [],
+  line_no: [2]
+});
+
+assert.ok(missingMap.rows['2']);
+assert.deepStrictEqual(missingMap.rows['2'].line_no.reasons, ['empty', 'flagged']);
+assert.strictEqual(missingMap.rows['2'].line_no.flagged, true);
+assert.deepStrictEqual(missingMap.columns.line_no.rows, [2]);
+assert.deepStrictEqual(missingMap.columns.line_no.details['2'], missingMap.rows['2'].line_no);
 
 assert.strictEqual(ssot.lineItems[1].line_no, ' ');
 


### PR DESCRIPTION
## Summary
- extend MasterDB.flatten to return CSV rows together with a structured missing-cell map
- expose the missing-cell diagnostics through a new "Export Missing Cells" control in the wizard UI
- update tests to cover the new structured data and ensure the JSON export uses the stored row flags

## Testing
- node test/master-db.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cb55f02350832bb215803a9d3cec48