### PR TITLE
Add hash routing and scoped state resets for invoice wizard

### DIFF
--- a/invoice-wizard.html
+++ b/invoice-wizard.html
@@ -30,7 +30,7 @@
     <nav class="tabs">
       <a href="index.html">Home</a>
       <a href="portfolio.html">Portfolio Preview</a>
-      <a class="active" href="invoice-wizard.html">Invoice Wizard</a>
+      <a class="active" href="invoice-wizard.html#/configure/invoice">Invoice Wizard</a>
     </nav>
 
     <header class="header">
@@ -247,6 +247,11 @@
   <script src="master-db.js"></script>
   <script src="orchestrator.js"></script>
   <script src="field-map.js"></script>
+  <script>
+    if (!/^#\/(configure|run)\//.test(window.location.hash)) {
+      window.location.replace('#/configure/invoice');
+    }
+  </script>
   <script src="invoice-wizard.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update the invoice wizard entry page to default to the new hash routes
- restructure the wizard state into shared/config/run slices with reset helpers and add a hash router to enter each mode
- adjust event handlers, login/logout, and batch processing to respect the router, clear per-mode caches, and avoid cross-mode persistence

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cda9caf210832ba7b630e3e4c1bc8d