### PR TITLE
Fix login redirect to open dashboard

### DIFF
--- a/invoice-wizard.js
+++ b/invoice-wizard.js
@@ -4784,7 +4784,7 @@ els.loginForm?.addEventListener('submit', (e)=>{
   populateModelSelect();
   renderResultsTable();
   renderReports();
-  handleRouteChange(true);
+  navigateToRoute('RUN', wizardKey, { replace: true, force: true });
 });
 els.logoutBtn?.addEventListener('click', ()=>{
   const configWizard = state.configMode.wizardId || state.docType || DEFAULT_WIZARD_ID;


### PR DESCRIPTION
## Summary
- update the login handler to route authenticated users to the run/dashboard view
- ensure the document dashboard is displayed right after login instead of configuration mode

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf072c3d30832b8467d5e56fae5558