### PR TITLE
WFG4: unify visual-surface intake and make visual geometry authoritative

### DIFF
--- a/docs/wfg4-visual-intake-replacement.md
+++ b/docs/wfg4-visual-intake-replacement.md
@@ -1,0 +1,76 @@
+# WFG4 Visual Intake Architecture Replacement (WFG3-style)
+
+Date: 2026-04-10
+
+## Scope
+This change replaces WFG4 downstream authority from mixed PDF/display viewport geometry to a **single visual-surface authority**.
+
+## Modified files and codepaths
+
+### 1) `invoice-wizard.js`
+
+#### Replaced viewport authority helpers
+- **Function modified:** `getWfg4CanonicalViewport(pageNum, modeHint)`
+- **Previous behavior:** Could reflect legacy canonical/page viewport assumptions derived from prior flow state.
+- **New behavior:** Viewport is read from WFG4 surface page dimensions (`working`/`original`) only.
+- **Why:** single-space visual authority for WFG4.
+
+- **Function modified:** `projectTokensToWfg4Canonical(tokens, ...)`
+- **Previous behavior:** could remap from `state.pageViewports/state.viewport` authority.
+- **New behavior:** remaps only against the WFG4 visual-surface viewport (or provided visual hint), never against PDF-view geometry authority.
+- **Why:** prevent PDF-space token authority from leaking downstream.
+
+#### Added unified visual intake builder
+- **Function added:** `cloneCanvasVisualSurface(inputCanvas, width, height)`
+- Clones an intake canvas into a detached visual canvas.
+
+- **Function added:** `buildWfg4VisualIntakePages()`
+- **Purpose:** source-agnostic intake convergence.
+  - Image: clone `els.imgCanvas` into page 1.
+  - PDF: clone per-page cached raster canvases from `state.wfg4.pageCanvases`.
+- **Result:** WFG4 receives pages as one shared visual representation regardless of source type.
+
+#### Replaced WFG4 surface capture model
+- **Function modified:** `captureWfg4SurfaceForMode(mode)`
+- **Previous behavior:** mixed dependence on page viewport arrays and fallback geometry.
+- **New behavior:** builds pages exclusively from `buildWfg4VisualIntakePages()` and sets active viewport from that visual page.
+- **Result:** after intake, WFG4 works from visual pages only.
+
+#### Token resolver behavior update (visual-first)
+- **Function modified:** `resolveExtractionTokensForField(...)`
+- **New rule:** visual OCR (`tesseract-bbox`) remains primary.
+- PDF text path is retained only as explicit request or fallback and marked non-authoritative in resolver reasons.
+- Projection for fallback tokens now uses visual/canonical viewport, not PDF viewport arrays.
+
+### 2) `engines/core/wfg4-capture-frame.js`
+
+#### Removed display viewport dependency in capture frame scaling
+- **Removed function:** `pickVp(state, idx)`
+- **Function modified:** `buildCaptureFrame(...)`
+- **Previous behavior:** display dimensions could be derived from `state.pageViewports/state.viewport`.
+- **New behavior:** display dimensions are set to WFG4 working dimensions directly (`display == working` for frame math authority).
+- **Result:** one geometry authority within CaptureFrame.
+
+#### Source typing updated to visual intake semantics
+- **Function modified:** `buildCaptureFrame(...)` (`sourceType` field)
+- **Previous behavior:** included `pdf-text-layer` classification branch.
+- **New behavior:** `image-visual-intake` or `pdf-raster-visual-intake`.
+- **Result:** removes text-layer-first semantic framing from geometry pipeline.
+
+## Removed/replaced authority patterns
+- Replaced WFG4 token projection dependence on legacy viewport arrays as authority.
+- Replaced WFG4 capture-page intake dependence on mixed viewport/page arrays with visual-page intake builder.
+- Removed CaptureFrame display-scaling dependence on state page viewport arrays.
+
+## Downstream authority model after change
+- **Page space:** WFG4 surface page dimensions (visual working surface).
+- **BBox space:** WFG4 working visual page coordinates.
+- **Token space:** projected into WFG4 visual page coordinates.
+- **Localization/extraction readout:** anchored to WFG4 visual surface + capture frame derived from it.
+
+## Notes for debugging
+If regressions appear, inspect these first:
+1. `buildWfg4VisualIntakePages()` output dimensions per page.
+2. `captureWfg4SurfaceForMode()` payload page list and active viewport.
+3. `projectTokensToWfg4Canonical()` input viewport hint and output scaling.
+4. `WFG4CaptureFrame.build()` display/working scale values.

--- a/engines/core/wfg4-capture-frame.js
+++ b/engines/core/wfg4-capture-frame.js
@@ -12,15 +12,6 @@
 (function(global){
   'use strict';
 
-  function pickVp(state, idx){
-    const vp = state?.pageViewports?.[idx] || state?.viewport || null;
-    if(!vp) return null;
-    const w = Number(vp.width ?? vp.w);
-    const h = Number(vp.height ?? vp.h);
-    if(!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0) return null;
-    return { width: Math.round(w), height: Math.round(h) };
-  }
-
   function invariantsReport({ pageNum, state }){
     const idx = Math.max(0, (Number(pageNum) || 1) - 1);
     const surface = state?.wfg4?.configSurface || null;
@@ -44,9 +35,8 @@
     const working = pageEntry.dimensions.working;
     const workingW = Math.max(1, Math.round(working.width));
     const workingH = Math.max(1, Math.round(working.height));
-    const vp = pickVp(state, idx) || { width: workingW, height: workingH };
-    const displayW = vp.width;
-    const displayH = vp.height;
+    const displayW = workingW;
+    const displayH = workingH;
     const sX = workingW / displayW;
     const sY = workingH / displayH;
 
@@ -74,11 +64,7 @@
 
     const frame = {
       pageNum: userBoxDisplay.page,
-      sourceType: state?.isImage
-        ? 'image'
-        : ((Array.isArray(state?.tokensByPage?.[userBoxDisplay.page]) && state.tokensByPage[userBoxDisplay.page].length)
-            ? 'pdf-text-layer'
-            : 'pdf-scanned-or-empty'),
+      sourceType: state?.isImage ? 'image-visual-intake' : 'pdf-raster-visual-intake',
       generation: Number(pageEntry.generation || 0),
       display: Object.freeze({ width: displayW, height: displayH }),
       working: Object.freeze({ width: workingW, height: workingH }),

--- a/invoice-wizard.js
+++ b/invoice-wizard.js
@@ -13878,9 +13878,9 @@ function getWfg4CanonicalViewport(pageNum, modeHint = null){
   const mode = modeHint || (isRunMode() ? 'run' : 'config');
   const surface = state.wfg4?.[mode === 'run' ? 'runSurface' : 'configSurface'] || null;
   const pageEntry = surface?.pages?.[page - 1] || null;
-  const working = pageEntry?.dimensions?.working || null;
-  const width = Number(working?.width || 0);
-  const height = Number(working?.height || 0);
+  const visual = pageEntry?.dimensions?.working || pageEntry?.dimensions?.original || null;
+  const width = Number(visual?.width || 0);
+  const height = Number(visual?.height || 0);
   if(width > 0 && height > 0){
     return { width, height, w: width, h: height, scale: 1, pageNumber: page };
   }
@@ -13891,17 +13891,11 @@ function projectTokensToWfg4Canonical(tokens = [], pageNum, modeHint = null, vie
   if(!Array.isArray(tokens) || !tokens.length) return [];
   const page = Math.max(1, Number(pageNum) || 1);
   const canonicalVp = getWfg4CanonicalViewport(page, modeHint);
-  if(!canonicalVp) return tokens.slice();
-  const sourceVp = viewportHint || state.pageViewports?.[page - 1] || state.viewport || canonicalVp;
-  const srcW = Math.max(1, Number(sourceVp.width ?? sourceVp.w ?? canonicalVp.width));
-  const srcH = Math.max(1, Number(sourceVp.height ?? sourceVp.h ?? canonicalVp.height));
-  const dstW = Math.max(1, Number(canonicalVp.width || canonicalVp.w || srcW));
-  const dstH = Math.max(1, Number(canonicalVp.height || canonicalVp.h || srcH));
-  const sx = dstW / srcW;
-  const sy = dstH / srcH;
-  if(Math.abs(sx - 1) < 0.0001 && Math.abs(sy - 1) < 0.0001){
-    return tokens.map(t => ({ ...t, page: t?.page || page }));
-  }
+  if(!canonicalVp) return tokens.map(t => ({ ...t, page: t?.page || page }));
+  const srcW = Math.max(1, Number(viewportHint?.width ?? viewportHint?.w ?? canonicalVp.width));
+  const srcH = Math.max(1, Number(viewportHint?.height ?? viewportHint?.h ?? canonicalVp.height));
+  const sx = canonicalVp.width / srcW;
+  const sy = canonicalVp.height / srcH;
   return tokens.map(tok => ({
     ...tok,
     x: Number(tok?.x || 0) * sx,
@@ -14006,62 +14000,60 @@ function clearWfg4PageRasterCache(){
   if(state.wfg4) state.wfg4.pageCanvases = {};
 }
 
-function captureWfg4SurfaceForMode(mode){
-  if(!window.WFG4Engine?.prepareDocumentSurface) return null;
-  const vp = state.pageViewports?.[(state.pageNum || 1) - 1] || state.viewport || null;
+function cloneCanvasVisualSurface(inputCanvas, width, height){
+  if(!inputCanvas) return null;
+  const w = Math.max(1, Math.round(width || inputCanvas.width || 1));
+  const h = Math.max(1, Math.round(height || inputCanvas.height || 1));
+  const out = document.createElement('canvas');
+  out.width = w;
+  out.height = h;
+  const ctx = out.getContext('2d');
+  if(ctx){
+    try { ctx.drawImage(inputCanvas, 0, 0, w, h); } catch(_err){}
+  }
+  return out;
+}
+
+function buildWfg4VisualIntakePages(){
   const pages = [];
   if(state.isImage){
     const imgNode = els.imgCanvas;
-    const imgW = Math.max(1, Math.round(imgNode?.width || state.viewport?.w || state.viewport?.width || 1));
-    const imgH = Math.max(1, Math.round(imgNode?.height || state.viewport?.h || state.viewport?.height || 1));
+    const width = Math.max(1, Math.round(imgNode?.width || 1));
+    const height = Math.max(1, Math.round(imgNode?.height || 1));
     if(imgNode){
-      const tmp = document.createElement('canvas');
-      tmp.width = imgW;
-      tmp.height = imgH;
-      const tctx = tmp.getContext('2d');
-      if(tctx){
-        try { tctx.drawImage(imgNode, 0, 0, imgW, imgH); } catch(_err){}
-      }
-      pages.push({ pageIndex: 0, pageNumber: 1, width: imgW, height: imgH, canvas: tmp });
+      const canvas = cloneCanvasVisualSurface(imgNode, width, height);
+      pages.push({ pageIndex: 0, pageNumber: 1, width, height, canvas });
     }
-  } else if(Array.isArray(state.pageViewports) && state.pageViewports.length){
-    for(let i=0; i<state.pageViewports.length; i++){
-      const pageVp = state.pageViewports[i] || {};
-      const fallbackW = Math.max(1, Math.round(pageVp.width || pageVp.w || 1));
-      const fallbackH = Math.max(1, Math.round(pageVp.height || pageVp.h || 1));
-      // Unified raster source: both config and run read the per-page canvas
-      // from state.wfg4.pageCanvases. The cache is populated synchronously
-      // (awaited) by renderAllPages (config) and prepareRunDocument (run) BEFORE
-      // syncWfg4SurfaceContext fires, so it is guaranteed to be available here.
-      // We pass the cached HTMLCanvasElement *directly* into the WFG4 page
-      // descriptor so downstream normalizePage → toCanvasFromSource consumes
-      // the exact same bits in both modes, with zero intermediate copies.
-      const cached = getWfg4CachedPageCanvas(i + 1);
-      if(!cached){
-        // Should not happen in normal flow; log so regressions surface loudly
-        // rather than silently diverging between modes.
-        console.warn('[wfg4] raster cache miss for page', i + 1, 'mode=', mode);
-        pages.push({ pageIndex: i, pageNumber: i + 1, width: fallbackW, height: fallbackH, canvas: null });
-        continue;
-      }
-      pages.push({
-        pageIndex: i,
-        pageNumber: i + 1,
-        width: cached.width || fallbackW,
-        height: cached.height || fallbackH,
-        canvas: cached
-      });
-    }
+    return pages;
   }
+  const bucket = ensureWfg4StateBucket();
+  const cached = bucket.pageCanvases || {};
+  const pageCount = Math.max(1, Number(state.numPages || Object.keys(cached).length || 1));
+  for(let i = 1; i <= pageCount; i++){
+    const src = cached[i] || null;
+    const width = Math.max(1, Math.round(src?.width || 1));
+    const height = Math.max(1, Math.round(src?.height || 1));
+    const canvas = src ? cloneCanvasVisualSurface(src, width, height) : null;
+    pages.push({ pageIndex: i - 1, pageNumber: i, width, height, canvas });
+  }
+  return pages;
+}
+
+function captureWfg4SurfaceForMode(mode){
+  if(!window.WFG4Engine?.prepareDocumentSurface) return null;
+  const pages = buildWfg4VisualIntakePages();
+  const activePage = Math.max(1, Math.min(pages.length || 1, Number(state.pageNum) || 1));
+  const active = pages[activePage - 1] || pages[0] || { width: 1, height: 1 };
+  const vp = { width: active.width, height: active.height, w: active.width, h: active.height, scale: 1, pageNumber: activePage };
   const payload = {
     mode,
     fileName: state.currentFileName || '',
-    mimeType: state.isImage ? 'image/*' : 'application/pdf',
+    mimeType: state.isImage ? 'image/*' : 'application/pdf-rasterized',
     isImage: !!state.isImage,
     geometryId: state.activeGeometryId || currentGeometryId() || null,
     wizardId: currentWizardId() || null,
-    pageCount: Number.isFinite(state.numPages) ? state.numPages : 0,
-    activePage: Number.isFinite(state.pageNum) ? state.pageNum : 1,
+    pageCount: pages.length,
+    activePage,
     viewport: vp,
     pages
   };
@@ -19744,7 +19736,6 @@ async function resolveExtractionTokensForField({ pageNum, preferredEngine = 'aut
   const page = Math.max(1, Number(pageNum) || 1);
   const enginePref = String(preferredEngine || 'auto').toLowerCase();
   const wantTesseract = enginePref === 'tesseract' || enginePref === 'tesseract-bbox';
-  const wantPdf = enginePref === 'pdfjs';
   const modeLabel = mode || (isRunMode() ? 'run' : (isConfigMode() ? 'config' : 'unknown'));
   const canonicalVp = getWfg4CanonicalViewport(page, modeLabel);
 
@@ -19766,39 +19757,38 @@ async function resolveExtractionTokensForField({ pageNum, preferredEngine = 'aut
     return buildResult(canonical, 'tesseract', 'tesseract-bbox', 'preferred_tesseract');
   }
 
-  if(wantPdf){
+  if(enginePref === 'pdfjs'){
     const pdfTokensRaw = await ensureTokensForPage(page);
-    const pdfTokens = projectTokensToWfg4Canonical(pdfTokensRaw, page, modeLabel, state.pageViewports?.[page - 1] || null);
+    const pdfTokens = projectTokensToWfg4Canonical(pdfTokensRaw, page, modeLabel, canonicalVp || null);
     const sourceInfo = getTokenSourceInfoForPage(page);
     const tokenSource = sourceInfo.acroTokenCount > 0 && sourceInfo.pdfTokenCount === 0 ? 'acroform' : 'pdfjs';
     const engineUsed = tokenSource === 'acroform' ? 'acroform' : 'pdfjs';
-    const reason = tokenSource === 'acroform' ? 'preferred_pdf_fallback_with_acroform_overlay' : 'preferred_pdf_fallback';
+    const reason = tokenSource === 'acroform' ? 'explicit_pdf_request_non_authoritative' : 'explicit_pdf_request_non_authoritative';
     return buildResult(pdfTokens, engineUsed, tokenSource, reason);
   }
 
-  // WFG4 canonical rule: source-agnostic OCR tokens are primary. PDF text is
-  // fallback-only and must not become authoritative merely because the source
-  // document is a PDF.
+  // Visual-first rule: OCR on the visual surface is always authoritative.
+  // PDF text layer never defines primary token geometry.
   const tessTokens = await ensureTesseractTokensForPageWithBBox(page);
   const normalized = normalizeTesseractTokensForPage(tessTokens, page);
   const canonicalTess = projectTokensToWfg4Canonical(normalized, page, modeLabel, canonicalVp || null);
   if(Array.isArray(canonicalTess) && canonicalTess.length){
-    return buildResult(canonicalTess, 'tesseract', 'tesseract-bbox', 'canonical_ocr_primary');
+    return buildResult(canonicalTess, 'tesseract', 'tesseract-bbox', 'visual_surface_ocr_primary');
   }
 
   const pdfTokensRaw = await ensureTokensForPage(page);
-  const pdfTokens = projectTokensToWfg4Canonical(pdfTokensRaw, page, modeLabel, state.pageViewports?.[page - 1] || null);
+  const pdfTokens = projectTokensToWfg4Canonical(pdfTokensRaw, page, modeLabel, canonicalVp || null);
   const sourceInfo = getTokenSourceInfoForPage(page);
   if(Array.isArray(pdfTokens) && pdfTokens.length){
     const tokenSource = sourceInfo.acroTokenCount > 0 && sourceInfo.pdfTokenCount === 0 ? 'acroform' : 'pdfjs';
     const engineUsed = tokenSource === 'acroform' ? 'acroform' : 'pdfjs';
-    const reason = tokenSource === 'acroform' ? 'acroform_tokens_fallback' : 'pdf_tokens_fallback';
+    const reason = tokenSource === 'acroform' ? 'acroform_tokens_visual_fallback' : 'pdf_tokens_visual_fallback';
     return buildResult(pdfTokens, engineUsed, tokenSource, reason, 'tesseract-bbox');
   }
 
   if(sourceInfo.acroTokenCount > 0){
     const acroRaw = Array.isArray(state.acroTokensByPage?.[page]) ? state.acroTokensByPage[page] : [];
-    const acroTokens = projectTokensToWfg4Canonical(acroRaw, page, modeLabel, state.pageViewports?.[page - 1] || null);
+    const acroTokens = projectTokensToWfg4Canonical(acroRaw, page, modeLabel, canonicalVp || null);
     return buildResult(acroTokens, 'acroform', 'acroform', 'acroform_tokens_fallback_without_pdf_text', 'tesseract-bbox');
   }
 


### PR DESCRIPTION
### Motivation
- Replace mixed PDF/display viewport geometry with a single visual-surface authority so all downstream WFG4 consumers use the same page geometry.
- Prevent PDF-space token authority from leaking into extraction and normalization pipelines by making rasterized/visual coordinates canonical.
- Simplify capture-frame math by removing reliance on `state.pageViewports` / `state.viewport` as a separate geometry authority.

### Description
- Added documentation `docs/wfg4-visual-intake-replacement.md` describing the new visual intake and authority model. 
- Updated `getWfg4CanonicalViewport` to read canonical dimensions from the WFG4 visual surface (`working` or `original`) instead of mixing legacy viewport sources. 
- Reworked token projection via `projectTokensToWfg4Canonical` to scale tokens only against the WFG4 visual viewport (or an explicit visual hint) and avoid using `state.pageViewports`/`state.viewport` as the source authority. 
- Introduced `cloneCanvasVisualSurface` and `buildWfg4VisualIntakePages` and replaced `captureWfg4SurfaceForMode` to build a unified visual intake (image or per-page raster canvases) and provide a single visual `viewport` payload to `WFG4Engine.prepareDocumentSurface`, including changing PDF mime to `application/pdf-rasterized`. 
- Updated token resolver semantics in `resolveExtractionTokensForField` to be visual-first (OCR `tesseract-bbox` authoritative), treating PDF text as explicit/fallback and marking it non-authoritative in resolver reasons. 
- Simplified `engines/core/wfg4-capture-frame.js` by removing `pickVp`, setting `display == working` for frame math, and renaming `sourceType` values to `image-visual-intake` / `pdf-raster-visual-intake` to reflect visual intake semantics. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92b5ced1c832ba9c85a831e8af7ee)