### PR TITLE
Fix WFG4 PDF crop scaling, require OCR-on-crop pipeline, and add forensic crop artifacts

### DIFF
--- a/dev-logs/wfg4-raster-first-image-only-cut.md
+++ b/dev-logs/wfg4-raster-first-image-only-cut.md
@@ -1,0 +1,45 @@
+# WFG4 Forensic Debug Note — PDF Crop Reads Above Box
+
+## Binary answer
+Are we OCRing the correct pixels for PDFs?
+**Before fix: NO** (when WFG4 canonical display is active and `original != working`).
+
+## Root cause (exact)
+`engines/core/wfg4-capture-frame.js` (`buildCaptureFrame`) treated `userBoxDisplayPx` as if it were in `pageEntry.dimensions.original`.
+
+In WFG4 config canonical mode, the user actually draws on the **canonical viewer surface** (`state.pageViewports`, i.e. working-sized display).
+
+So for PDFs where `original` is larger than `working`, this extra conversion:
+- `sX = workingW / originalW`
+- `sY = workingH / originalH`
+
+scaled the already-working-space display box **again**, shifting OCR crop origin upward/left.
+
+This matches the observed bug: OCR reading text above the selected box.
+
+## First divergence point
+- **File:** `engines/core/wfg4-capture-frame.js`
+- **Function:** `buildCaptureFrame`
+- **Variables:** `displayW`, `displayH`, `sX`, `sY`, `userBoxDisplayPx -> userBoxWorkingPx`
+- **Divergence:** PDF canonical display still used `original` dims for display basis instead of active viewer dims.
+
+## Fix implemented
+1. In `buildCaptureFrame`, when `state.wfg4.configDisplayActive` is true, display dimensions now come from active page viewport (`state.pageViewports[idx]`) rather than `original`.
+2. Mirrored the same fix in config fallback mapping path inside `invoice-wizard.js` confirm flow.
+3. Added forensic logging + crop artifact output in `ocrWfg4CropReadout`:
+   - logs display/stored/working boxes
+   - logs source canvas identity + dimensions
+   - writes debug crops and metadata:
+     - `debug/wfg4-crops/crop_image_from_pdf.png`
+     - `debug/wfg4-crops/crop_image_from_image.png`
+     - matching `.json` files with exact coordinates
+
+## Where to inspect runtime forensic output
+- Console logs:
+  - `[wfg4-box-debug]`
+  - `[wfg4-crop-debug]`
+- Files:
+  - `debug/wfg4-crops/crop_image_from_pdf.png`
+  - `debug/wfg4-crops/crop_image_from_image.png`
+  - `debug/wfg4-crops/crop_image_from_pdf.json`
+  - `debug/wfg4-crops/crop_image_from_image.json`

--- a/engines/core/wfg4-capture-frame.js
+++ b/engines/core/wfg4-capture-frame.js
@@ -58,8 +58,20 @@
     const original = pageEntry.dimensions.original;
     const workingW = Math.max(1, Math.round(working.width));
     const workingH = Math.max(1, Math.round(working.height));
-    const displayW = Math.max(1, Math.round(original.width));
-    const displayH = Math.max(1, Math.round(original.height));
+    // Critical forensic fix:
+    // userBoxDisplayPx is drawn on the *currently rendered viewer surface*.
+    // In WFG4 config canonical mode, viewer pages are rendered in working
+    // dimensions (state.pageViewports), not original PDF raster dims.
+    // Using original dims here scales the user's box down a second time on
+    // PDFs where original != working, which shifts crops upward/left.
+    const canonicalDisplayActive = !!state?.wfg4?.configDisplayActive;
+    const displayVp = Array.isArray(state?.pageViewports) ? state.pageViewports[idx] : null;
+    const displayW = canonicalDisplayActive
+      ? Math.max(1, Math.round(Number(displayVp?.width ?? displayVp?.w ?? workingW) || workingW))
+      : Math.max(1, Math.round(original.width));
+    const displayH = canonicalDisplayActive
+      ? Math.max(1, Math.round(Number(displayVp?.height ?? displayVp?.h ?? workingH) || workingH))
+      : Math.max(1, Math.round(original.height));
     const sX = workingW / displayW;
     const sY = workingH / displayH;
 

--- a/engines/core/wfg4-engine.js
+++ b/engines/core/wfg4-engine.js
@@ -25,112 +25,6 @@
     return String(text || '').replace(/\s+/g, ' ').replace(/[#:]+$/g, '').trim();
   }
 
-  function expandBox(box, pad){
-    return {
-      x: (box?.x || 0) - pad,
-      y: (box?.y || 0) - pad,
-      w: Math.max(1, (box?.w || 1) + (pad * 2)),
-      h: Math.max(1, (box?.h || 1) + (pad * 2)),
-      page: box?.page
-    };
-  }
-
-  function tokensInBox(tokens, box, minOverlap = 0.25){
-    if(!Array.isArray(tokens) || !box) return [];
-    return tokens.filter(tok => {
-      const x0 = tok.x || 0;
-      const y0 = tok.y || 0;
-      const x1 = x0 + (tok.w || 0);
-      const y1 = y0 + (tok.h || 0);
-      const ox = Math.max(0, Math.min(box.x + box.w, x1) - Math.max(box.x, x0));
-      const oy = Math.max(0, Math.min(box.y + box.h, y1) - Math.max(box.y, y0));
-      const overlap = ox * oy;
-      const area = Math.max(1, (tok.w || 0) * (tok.h || 0));
-      return overlap / area >= minOverlap;
-    });
-  }
-
-  function uniqueTokens(tokens){
-    const seen = new Set();
-    const out = [];
-    for(const tok of (Array.isArray(tokens) ? tokens : [])){
-      if(!tok) continue;
-      const text = String(tok.text || tok.raw || '').trim();
-      if(!text) continue;
-      const key = [
-        text,
-        Math.round(Number(tok.x || 0)),
-        Math.round(Number(tok.y || 0)),
-        Math.round(Number(tok.w || 0)),
-        Math.round(Number(tok.h || 0)),
-        Number(tok.page || 0)
-      ].join('|');
-      if(seen.has(key)) continue;
-      seen.add(key);
-      out.push(tok);
-    }
-    return out;
-  }
-
-  function sortTokensReadingOrder(tokens){
-    const ordered = uniqueTokens(tokens).slice().sort((a, b) => {
-      const ay = Number(a.y || 0);
-      const by = Number(b.y || 0);
-      if(Math.abs(ay - by) > 2) return ay - by;
-      return Number(a.x || 0) - Number(b.x || 0);
-    });
-    if(!ordered.length) return [];
-    const heights = ordered.map(t => Math.max(1, Number(t.h || 1))).filter(Number.isFinite);
-    const medianH = heights.length
-      ? heights.slice().sort((a,b)=>a-b)[Math.floor(heights.length / 2)]
-      : 12;
-    const bandTol = Math.max(3, medianH * 0.6);
-    const rows = [];
-    for(const tok of ordered){
-      const cy = Number(tok.y || 0) + (Number(tok.h || 0) * 0.5);
-      let row = rows.find(r => Math.abs(cy - r.cy) <= bandTol);
-      if(!row){
-        row = { cy, toks: [] };
-        rows.push(row);
-      }
-      row.toks.push(tok);
-      row.cy = (row.cy * (row.toks.length - 1) + cy) / row.toks.length;
-    }
-    rows.sort((a,b)=> a.cy - b.cy);
-    for(const r of rows){
-      r.toks.sort((a,b)=> Number(a.x || 0) - Number(b.x || 0));
-    }
-    return rows.flatMap(r => r.toks);
-  }
-
-  function aggregateTokenText(tokens){
-    const ordered = sortTokensReadingOrder(tokens);
-    if(!ordered.length) return '';
-    const heights = ordered.map(t => Math.max(1, Number(t.h || 1))).filter(Number.isFinite);
-    const medianH = heights.length
-      ? heights.slice().sort((a,b)=>a-b)[Math.floor(heights.length / 2)]
-      : 12;
-    const newLineTol = Math.max(5, medianH * 0.9);
-    const lines = [];
-    let line = [];
-    let lineCy = null;
-    for(const tok of ordered){
-      const text = String(tok.text || tok.raw || '').trim();
-      if(!text) continue;
-      const cy = Number(tok.y || 0) + (Number(tok.h || 0) * 0.5);
-      if(line.length && lineCy !== null && Math.abs(cy - lineCy) > newLineTol){
-        lines.push(line.join(' '));
-        line = [text];
-        lineCy = cy;
-      } else {
-        line.push(text);
-        lineCy = lineCy === null ? cy : ((lineCy * (line.length - 1) + cy) / line.length);
-      }
-    }
-    if(line.length) lines.push(line.join(' '));
-    return cleanText(lines.join(' ').replace(/\s+/g, ' '));
-  }
-
   function toCanvasFromSource(source){
     if(!source) return null;
     if(typeof HTMLCanvasElement !== 'undefined' && source instanceof HTMLCanvasElement){
@@ -466,23 +360,6 @@
     };
   }
 
-  function mapTokensToCanonical(tokens, boxPx, wfg4Surface){
-    if(!Array.isArray(tokens) || !boxPx || !wfg4Surface?.pages) return tokens || [];
-    const pageIdx = Math.max(0, (boxPx.page || 1) - 1);
-    const page = wfg4Surface.pages[pageIdx];
-    if(!page?.scale) return tokens;
-    const sx = Number(page.scale.workingFromOriginalX || 1);
-    const sy = Number(page.scale.workingFromOriginalY || 1);
-    if(Math.abs(sx - 1) < 0.001 && Math.abs(sy - 1) < 0.001) return tokens;
-    return tokens.map(tok => ({
-      ...tok,
-      x: Number(tok.x || 0) * sx,
-      y: Number(tok.y || 0) * sy,
-      w: Number(tok.w || 0) * sx,
-      h: Number(tok.h || 0) * sy
-    }));
-  }
-
   function resolvePageAlignmentV1(payload = {}){
     const fieldSpec = payload.fieldSpec || {};
     const ref = fieldSpec.wfg4Config || payload.wfg4Config || null;
@@ -515,21 +392,7 @@
   async function extractScalar(payload = {}){
     const fieldSpec = payload.fieldSpec || {};
     const boxPx = payload.boxPx || null;
-    const rawTokens = Array.isArray(payload.tokens) ? payload.tokens : [];
-    // P0 coordinate-space unification: `mapTokensToCanonical` promotes tokens
-    // from viewport into working-surface space via workingFromOriginalX/Y. In
-    // run mode that is correct (Phase 6 produces a working-space reconstructed
-    // box, so tokens must match). In config-mode-authoritative, however, the
-    // box is the user's literal bbox in viewport space, so promoting tokens
-    // while leaving the box in viewport space is a space mismatch that causes
-    // token scoping to fail, `needsLocalizedReadout` to fire unconditionally,
-    // and wrong-target extraction on any surface where working ≠ viewport.
-    // Keep tokens in viewport space when the box is viewport-space.
     const _configAuth = !!payload.configMode && !!boxPx;
-    const tokensAlreadyCanonical = !!payload.tokensCanonical;
-    const allTokens = _configAuth
-      ? rawTokens
-      : (tokensAlreadyCanonical ? rawTokens : mapTokensToCanonical(rawTokens, boxPx, payload.wfg4Surface || null));
     const _EL = root.EngineLog || null;
     const _fk = fieldSpec.fieldKey || '';
     const _surfReady = !!(payload.wfg4Surface && Array.isArray(payload.wfg4Surface.pages) && payload.wfg4Surface.pages.length > 0);
@@ -538,7 +401,7 @@
       page: fieldSpec.page || null,
       hasWfg4Config: !!(fieldSpec.wfg4Config || payload.wfg4Config),
       surfaceReady: _surfReady,
-      tokenCount: rawTokens.length
+      tokenCount: 0
     });
 
     const allowDegradedFallback = !!(payload.allowDegradedFallback ?? fieldSpec.allowDegradedFallback ?? (Types.DEFAULTS && Types.DEFAULTS.allowDegradedFallback));
@@ -581,7 +444,7 @@
         fieldKey: _fk,
         boxPx: { x: boxPx.x, y: boxPx.y, w: boxPx.w, h: boxPx.h, page: boxPx.page },
         surfaceReady: _surfReady,
-        tokenCount: rawTokens.length
+        tokenCount: 0
       });
     }
 
@@ -667,78 +530,34 @@
       };
     }
 
-    const pads = [0, 4, 8];
-    let readout = null;
-    for(const pad of pads){
-      const scoped = tokensInBox(allTokens, pad ? expandBox(finalBox, pad) : finalBox, 0.2);
-      const aggregated = aggregateTokenText(scoped);
-      if(aggregated){
-        readout = { text: aggregated, pad, scoped };
-        if(pad === 0) break;
-      }
-    }
-
-    if(!readout){
-      // Localization is authoritative: the field location is real. Token
-      // scoping failure here means the current readout backend (PDF text
-      // layer tokens or pre-fetched OCR tokens) did not cover the localized
-      // region. The pipeline should attempt a localized readout on finalBox
-      // using an image/OCR backend regardless of source type. We hand that
-      // responsibility to the caller via `needsLocalizedReadout`.
-      _EL?.engineLog('wfg4-run', 'gate.decision', { fieldKey: _fk, gate: 'needsLocalizedReadout', reason: 'no_token_in_localized_scope', bboxSource });
-      _EL?.engineLog('wfg4-run', 'field.result', { fieldKey: _fk, engineUsed: 'wfg4', localizationStatus, bboxSource, fallbackUsed, value: '', needsReview: false, method: 'wfg4-localized-needs-readout' });
-      return {
-        value: '',
-        raw: '',
-        confidence: 0,
-        boxPx: finalBox,
-        tokens: [],
-        method: 'wfg4-localized-needs-readout',
-        engine: 'wfg4',
-        lowConfidence: false,
-        needsReview: false,
-        needsLocalizedReadout: true,
-        tokenSource: tokenSourceResolved,
-        extractionMeta: buildMeta({ reason: 'no_token_in_localized_scope_pending_readout' })
-      };
-    }
-
-    const value = cleanText(readout.text || '');
-    const densityBoost = Math.min(0.2, Math.max(0, (readout.scoped.length - 1) * 0.02));
-    const readConfidence = Math.max(
-      0.25,
-      Math.min(0.9, 0.55 + (Number(localized.localizationConfidence || 0) * 0.25) + densityBoost)
-    );
-    const _method = readout.pad ? 'wfg4-localized-micro-expansion' : 'wfg4-localized-in-box';
-    _EL?.engineLog('wfg4-run', 'gate.decision', { fieldKey: _fk, gate: 'pass', bboxSource });
+    // WFG4 hard cut: no token/text-layer readout in engine. Engine authority is
+    // localization only; caller must OCR exact finalBox pixels on the canonical
+    // visual surface.
+    _EL?.engineLog('wfg4-run', 'gate.decision', { fieldKey: _fk, gate: 'needsLocalizedReadout', reason: 'ocr_crop_only_pipeline', bboxSource });
     _EL?.engineLog('wfg4-run', 'field.result', {
       fieldKey: _fk,
       engineUsed: 'wfg4',
       localizationStatus,
       bboxSource,
       fallbackUsed,
-      value: value,
+      value: '',
       needsReview: false,
-      method: _method,
+      method: 'wfg4-localized-ocr-required',
       tokenSource: tokenSourceResolved,
-      confidence: readConfidence
+      confidence: 0
     });
     return {
-      value,
-      raw: value,
-      confidence: readConfidence,
+      value: '',
+      raw: '',
+      confidence: 0,
       boxPx: finalBox,
-      tokens: readout.scoped,
-      method: _method,
+      tokens: [],
+      method: 'wfg4-localized-ocr-required',
       engine: 'wfg4',
+      needsLocalizedReadout: true,
       tokenSource: tokenSourceResolved,
       extractionMeta: buildMeta({
-        usedPad: readout.pad,
-        scopedTokenCount: readout.scoped.length,
-        readout: {
-          confidence: readConfidence,
-          source: 'localized-full-box-aggregation'
-        }
+        reason: 'ocr_crop_only_pipeline_pending_readout'
       })
     };
   }

--- a/invoice-wizard.js
+++ b/invoice-wizard.js
@@ -10099,44 +10099,158 @@ async function applyAnyFieldVerifier(cleaned, { fieldKey, boxPx, pageNum, pageCa
   return { cleaned, patchedText: null };
 }
 
-  /**
-   * P1 CaptureFrame: run Tesseract directly against a crop from the frame's
-   * offscreen canonical canvas, returning tokens already expressed in the
-   * frame's working pixel space (i.e. in the same space as
-   * captureFrame.userBoxWorkingPx). No coordScale fudging required — the
-   * source pixels and the query box live in the exact same space.
-   */
-  async function ocrBoxFromCaptureFrame(captureFrame, boxInWorking){
-    if(!captureFrame || !boxInWorking) return [];
-    if(!window.TesseractRef && !window.Tesseract) return [];
-    const TesseractLib = window.TesseractRef || window.Tesseract;
-    const crop = captureFrame.cropWorkingImage(boxInWorking);
-    if(!crop) return [];
-    const offsetX = Math.max(0, Math.round(boxInWorking.x));
-    const offsetY = Math.max(0, Math.round(boxInWorking.y));
+  function aggregateOcrWords(words = []){
+    const ordered = words.slice().sort((a, b) => {
+      const ay = Number(a?.bbox?.y0 ?? a?.bbox?.y ?? 0);
+      const by = Number(b?.bbox?.y0 ?? b?.bbox?.y ?? 0);
+      if(Math.abs(ay - by) > 2) return ay - by;
+      const ax = Number(a?.bbox?.x0 ?? a?.bbox?.x ?? 0);
+      const bx = Number(b?.bbox?.x0 ?? b?.bbox?.x ?? 0);
+      return ax - bx;
+    });
+    const lines = [];
+    let current = [];
+    let currentY = null;
+    let confSum = 0;
+    let confCount = 0;
+    for(const w of ordered){
+      const text = String(w?.text || '').trim();
+      if(!text) continue;
+      const bbox = getTesseractWordBBox(w);
+      const cy = Number(bbox.y || 0) + (Number(bbox.h || 0) * 0.5);
+      const tol = Math.max(4, Number(bbox.h || 12) * 0.8);
+      if(current.length && currentY !== null && Math.abs(cy - currentY) > tol){
+        lines.push(current.join(' '));
+        current = [text];
+        currentY = cy;
+      } else {
+        current.push(text);
+        currentY = currentY === null ? cy : ((currentY * (current.length - 1) + cy) / current.length);
+      }
+      confSum += Number(w?.confidence || 0);
+      confCount += 1;
+    }
+    if(current.length) lines.push(current.join(' '));
+    return {
+      text: lines.join(' ').replace(/\s+/g, ' ').trim(),
+      meanConfidence: confCount > 0 ? (confSum / confCount) / 100 : 0
+    };
+  }
+
+  function cropCanvasByBox(sourceCanvas, boxPx){
+    if(!sourceCanvas || !boxPx) return null;
+    const sx = Math.max(0, Math.floor(Number(boxPx.x || 0)));
+    const sy = Math.max(0, Math.floor(Number(boxPx.y || 0)));
+    const sw = Math.max(1, Math.ceil(Number(boxPx.w || 1)));
+    const sh = Math.max(1, Math.ceil(Number(boxPx.h || 1)));
+    if(typeof document === 'undefined') return null;
+    const out = document.createElement('canvas');
+    out.width = sw;
+    out.height = sh;
+    const ctx = out.getContext('2d');
+    if(!ctx) return null;
+    ctx.drawImage(sourceCanvas, sx, sy, sw, sh, 0, 0, sw, sh);
+    return out;
+  }
+
+  function dumpWfg4CropDebugArtifact({ sourceKind = 'unknown', cropCanvas = null, boxPx = null, captureFrame = null, wfg4Surface = null, page = 1, sourceCanvas = null, sourceLabel = '' } = {}){
     try {
-      const { data } = await TesseractLib.recognize(crop, 'eng', { tessedit_pageseg_mode: 6, oem: 1 });
-      return (data?.words || []).map(w => {
-        const rawText = String(w.text || '').trim();
-        if(!rawText) return null;
-        const { text: corrected, corrections } = applyOcrCorrections(rawText);
-        const bbox = getTesseractWordBBox(w);
-        return {
-          raw: rawText,
-          corrected,
-          text: corrected,
-          correctionsApplied: corrections,
-          confidence: (w.confidence || 0) / 100,
-          x: (bbox.x || 0) + offsetX,
-          y: (bbox.y || 0) + offsetY,
-          w: bbox.w || 0,
-          h: bbox.h || 0,
-          page: captureFrame.pageNum
-        };
-      }).filter(Boolean);
+      const payload = {
+        sourceKind,
+        page,
+        boxPx: boxPx ? {
+          x: Number(boxPx.x || 0),
+          y: Number(boxPx.y || 0),
+          w: Number(boxPx.w || 0),
+          h: Number(boxPx.h || 0),
+          page: Number(boxPx.page || page || 1)
+        } : null,
+        displayBox: state.snappedPx ? {
+          x: Number(state.snappedPx.x || 0),
+          y: Number(state.snappedPx.y || 0),
+          w: Number(state.snappedPx.w || 0),
+          h: Number(state.snappedPx.h || 0),
+          page: Number(state.snappedPx.page || page || 1)
+        } : null,
+        captureFrame: captureFrame ? {
+          display: captureFrame.display,
+          working: captureFrame.working,
+          scale: captureFrame.scale,
+          userBoxDisplayPx: captureFrame.userBoxDisplayPx,
+          userBoxWorkingPx: captureFrame.userBoxWorkingPx
+        } : null,
+        sourceCanvas: sourceCanvas ? {
+          width: Number(sourceCanvas.width || 0),
+          height: Number(sourceCanvas.height || 0),
+          label: sourceLabel
+        } : null,
+        cropCanvas: cropCanvas ? {
+          width: Number(cropCanvas.width || 0),
+          height: Number(cropCanvas.height || 0)
+        } : null,
+        wfg4PageDims: wfg4Surface?.pages?.[Math.max(0, page - 1)]?.dimensions || null
+      };
+      console.log('[wfg4-crop-debug]', payload);
+      const fs = window.fs || (window.require && window.require('fs'));
+      if(!fs || !cropCanvas?.toDataURL) return;
+      const dir = 'debug/wfg4-crops';
+      fs.mkdirSync(dir, { recursive: true });
+      const base = sourceKind === 'pdf' ? 'crop_image_from_pdf' : (sourceKind === 'image' ? 'crop_image_from_image' : 'crop_image_from_unknown');
+      const dataUrl = cropCanvas.toDataURL('image/png');
+      const b64 = String(dataUrl).split(',')[1] || '';
+      if(b64 && typeof Buffer !== 'undefined'){
+        fs.writeFileSync(`${dir}/${base}.png`, Buffer.from(b64, 'base64'));
+      }
+      fs.writeFileSync(`${dir}/${base}.json`, JSON.stringify(payload, null, 2));
     } catch(err){
-      console.warn('[wfg4] ocrBoxFromCaptureFrame failed', err);
-      return [];
+      console.warn('[wfg4-crop-debug] artifact write failed', err);
+    }
+  }
+
+  async function ocrWfg4CropReadout({ captureFrame = null, wfg4Surface = null, boxPx = null, page = 1 } = {}){
+    const tesseract = window.TesseractRef || window.Tesseract;
+    if(!tesseract || !boxPx) return { text: '', confidence: 0, method: 'wfg4-ocr-missing' };
+    let cropCanvas = null;
+    let sourceCanvas = null;
+    let sourceLabel = '';
+    if(captureFrame && captureFrame.pageNum === page && captureFrame.getOffscreenCanonicalCanvas){
+      sourceCanvas = captureFrame.getOffscreenCanonicalCanvas();
+      sourceLabel = 'captureFrame.offscreenCanonical';
+      cropCanvas = captureFrame.cropWorkingImage(boxPx);
+    } else {
+      const pageEntry = wfg4Surface?.pages?.[Math.max(0, page - 1)] || null;
+      const displayDataUrl = pageEntry?.artifacts?.displayDataUrl || null;
+      if(displayDataUrl){
+        const pageCanvas = await dataUrlToCanvas(displayDataUrl);
+        if(pageCanvas){
+          sourceCanvas = pageCanvas;
+          sourceLabel = 'wfg4Surface.page.artifacts.displayDataUrl';
+          cropCanvas = cropCanvasByBox(pageCanvas, boxPx);
+        }
+      }
+    }
+    dumpWfg4CropDebugArtifact({
+      sourceKind: state.isImage ? 'image' : 'pdf',
+      cropCanvas,
+      boxPx,
+      captureFrame,
+      wfg4Surface,
+      page,
+      sourceCanvas,
+      sourceLabel
+    });
+    if(!cropCanvas) return { text: '', confidence: 0, method: 'wfg4-ocr-crop-missing' };
+    try {
+      const { data } = await tesseract.recognize(cropCanvas, 'eng', { tessedit_pageseg_mode: 6, oem: 1 });
+      const aggregated = aggregateOcrWords(Array.isArray(data?.words) ? data.words : []);
+      return {
+        text: aggregated.text,
+        confidence: aggregated.meanConfidence,
+        method: 'wfg4-crop-ocr-exact'
+      };
+    } catch(err){
+      console.warn('[wfg4] ocrWfg4CropReadout failed', err);
+      return { text: '', confidence: 0, method: 'wfg4-ocr-failed' };
     }
   }
 
@@ -10208,7 +10322,9 @@ async function applyAnyFieldVerifier(cleaned, { fieldKey, boxPx, pageNum, pageCa
       : null;
     let resolvedBox = captureFrame
       ? captureFrame.userBoxWorkingPx
-      : (pinnedWfg4Box || fallbackWorkingBox || state.snappedPx || null);
+      : (fieldEngineType === ENGINE_KIND.WFG4
+        ? (pinnedWfg4Box || fallbackWorkingBox || null)
+        : (state.snappedPx || null));
     if(!resolvedBox && fieldSpec.bbox){
       const viewportDims = getViewportDimensions(viewportPx);
       const rawBox = toPx(viewportPx, {x0:fieldSpec.bbox[0], y0:fieldSpec.bbox[1], x1:fieldSpec.bbox[2], y1:fieldSpec.bbox[3], page:fieldSpec.page});
@@ -10231,12 +10347,7 @@ async function applyAnyFieldVerifier(cleaned, { fieldKey, boxPx, pageNum, pageCa
         ? (getWfg4CanonicalViewport(fieldSpec.page || state.pageNum || 1, _isConfigModeNow ? 'config' : 'run') || viewportPx || null)
         : (viewportPx || null);
       const canonicalTokens = (fieldEngineType === ENGINE_KIND.WFG4)
-        ? projectTokensToWfg4Canonical(
-            Array.isArray(tokens) ? tokens : [],
-            fieldSpec.page || state.pageNum || 1,
-            _isConfigModeNow ? 'config' : 'run',
-            viewportPx || null
-          )
+        ? []
         : (Array.isArray(tokens) ? tokens : []);
       if(!captureFrame && pinnedWfg4Box && fieldSpec.bbox){
         const fallbackViewportBox = applyTransform(toPx(viewportPx, {
@@ -10290,83 +10401,43 @@ async function applyAnyFieldVerifier(cleaned, { fieldKey, boxPx, pageNum, pageCa
         // truth; the readout backend just needs to be tried on that bbox.
         // This is the source-agnostic OCR readout pass, used for both PDFs
         // and images.
-        if(engineResult?.needsLocalizedReadout && engineResult?.boxPx){
+        if(fieldEngineType === ENGINE_KIND.WFG4 && engineResult?.boxPx){
           try {
             const targetPage = Math.max(1, Number(engineResult.boxPx.page || fieldSpec.page || state.pageNum || 1) || 1);
-            // P1 CaptureFrame path: when we have a frame, OCR is run directly
-            // against the frame's crop of the offscreen canonical canvas. Both
-            // the crop and engineResult.boxPx live in working pixel space, so
-            // there is no scale translation to get wrong.
-            let tessTokens;
-            if(captureFrame && captureFrame.pageNum === targetPage && captureFrame.getOffscreenCanonicalCanvas()){
-              tessTokens = await ocrBoxFromCaptureFrame(captureFrame, engineResult.boxPx);
-            } else {
-              tessTokens = await ensureTesseractTokensForPageWithBBox(targetPage);
-            }
-            const normalized = (captureFrame && captureFrame.pageNum === targetPage && captureFrame.getOffscreenCanonicalCanvas())
-              ? (tessTokens || [])
-              : (normalizeTesseractTokensForPage(tessTokens, targetPage) || []);
-            const scoped = tokensInBox(normalized, engineResult.boxPx, { minOverlap: 0.2 });
-            const ordered = scoped.slice().sort((a,b) => {
-              const ay = Number(a.y || 0);
-              const by = Number(b.y || 0);
-              if(Math.abs(ay - by) > 2) return ay - by;
-              return Number(a.x || 0) - Number(b.x || 0);
+            const readout = await ocrWfg4CropReadout({
+              captureFrame,
+              wfg4Surface,
+              boxPx: engineResult.boxPx,
+              page: targetPage
             });
-            const heights = ordered.map(t => Math.max(1, Number(t.h || 1))).filter(Number.isFinite);
-            const medianH = heights.length ? heights.slice().sort((a,b)=>a-b)[Math.floor(heights.length / 2)] : 12;
-            const lineTol = Math.max(5, medianH * 0.9);
-            let lineCy = null;
-            let line = [];
-            const lines = [];
-            let confSum = 0;
-            let confCount = 0;
-            for(const tok of ordered){
-              const text = String(tok.text || tok.raw || '').trim();
-              if(!text) continue;
-              const cy = Number(tok.y || 0) + (Number(tok.h || 0) * 0.5);
-              if(line.length && lineCy !== null && Math.abs(cy - lineCy) > lineTol){
-                lines.push(line.join(' '));
-                line = [text];
-                lineCy = cy;
-              } else {
-                line.push(text);
-                lineCy = lineCy === null ? cy : ((lineCy * (line.length - 1) + cy) / line.length);
-              }
-              const c = Number.isFinite(tok.confidence) ? Number(tok.confidence) : 0.5;
-              confSum += c;
-              confCount += 1;
-            }
-            if(line.length) lines.push(line.join(' '));
-            const aggregatedText = lines.join(' ').replace(/\s+/g, ' ').trim();
+            const aggregatedText = String(readout?.text || '').trim();
             if(aggregatedText){
-              const meanConf = confCount > 0 ? (confSum / confCount) : 0.6;
+              const meanConf = Number.isFinite(readout?.confidence) ? readout.confidence : 0.6;
               const readConf = Math.max(0.3, Math.min(0.9, 0.45 + (meanConf * 0.35)));
               readoutAugmented = {
                 ...engineResult,
                 value: aggregatedText,
                 raw: aggregatedText,
                 confidence: readConf,
-                tokens: scoped,
-                method: 'wfg4-localized-readout-tesseract',
-                tokenSource: 'tesseract-bbox',
+                tokens: [],
+                method: readout.method || 'wfg4-crop-ocr-exact',
+                tokenSource: null,
                 needsReview: false,
                 lowConfidence: false,
                 extractionMeta: {
                   ...(engineResult.extractionMeta || {}),
-                  readoutBackend: 'tesseract-localized',
-                  tokenSourceResolved: 'tesseract-bbox',
+                  readoutBackend: 'wfg4-crop-ocr',
+                  tokenSourceResolved: null,
                   readout: {
                     ...((engineResult.extractionMeta && engineResult.extractionMeta.readout) || {}),
-                    source: 'localized-full-box-aggregation'
+                    source: 'localized-exact-crop-ocr'
                   }
                 }
               };
               window.EngineLog?.engineLog('wfg4-run', 'readout.localized', {
                 fieldKey: fieldSpec.fieldKey || null,
-                backend: 'tesseract',
+                backend: 'wfg4-crop-ocr',
                 value: aggregatedText,
-                tokenCount: scoped.length,
                 meanConf: Number(meanConf.toFixed(3))
               });
             } else {
@@ -10381,7 +10452,7 @@ async function applyAnyFieldVerifier(cleaned, { fieldKey, boxPx, pageNum, pageCa
                 confidence: 0.08,
                 extractionMeta: {
                   ...(engineResult.extractionMeta || {}),
-                  readoutBackend: 'tesseract-localized',
+                  readoutBackend: 'wfg4-crop-ocr',
                   readoutResult: 'empty'
                 }
               };
@@ -12649,6 +12720,7 @@ async function openFile(file){
   state.acroTokensByPage = {};
   state.pdfTextTokenCountByPage = {};
   const isImage = /^image\//.test(file.type || '');
+  const wfg4Selected = getConfiguredEngineType() === ENGINE_KIND.WFG4;
   state.isImage = isImage;
 
   if (isImage) {
@@ -12660,6 +12732,11 @@ async function openFile(file){
     state.pageNum = 1; state.numPages = 1;
     updatePageIndicator();
     if(els.pageControls) els.pageControls.style.display = 'none';
+    if(wfg4Selected){
+      await syncWfg4SurfaceContext('config');
+      drawOverlay();
+      return;
+    }
     try {
       const tokens = await ensureTokensForPage(1);
       await buildKeywordIndexForPage(1, tokens);
@@ -12678,7 +12755,6 @@ async function openFile(file){
     if(!state.graphLearning?.active && !state.objectLearning?.active){
       if(!(state.profile?.globals||[]).length) captureGlobalLandmarks();
       else await calibrateIfNeeded();
-      syncWfg4SurfaceContext('config');
       drawOverlay();
     }
     return;
@@ -12701,13 +12777,17 @@ async function openFile(file){
     els.viewer.scrollTop = 0;
     updatePageIndicator();
     if(els.pageControls) els.pageControls.style.display = 'none';
+    if(wfg4Selected){
+      await syncWfg4SurfaceContext('config');
+      drawOverlay();
+      return;
+    }
     // Skip profile-dependent operations for Graph/Object Learning (WFG2) — they do
     // not require a wizard/profile and only need the rendered surface.
     if(!state.graphLearning?.active && !state.objectLearning?.active){
       await ensureTokensForPage(1);
       if(!(state.profile?.globals||[]).length) captureGlobalLandmarks();
       else await calibrateIfNeeded();
-      syncWfg4SurfaceContext('config');
       drawOverlay();
     } else {
       try { await ensureTokensForPage(1); } catch(_){ /* best-effort for graph learning */ }
@@ -12835,6 +12915,7 @@ async function prepareRunDocument(file){
   state.snapshotDirty = state.snapshotMode;
 
   const isImage = /^image\//.test(file.type || '');
+  const wfg4Selected = getConfiguredEngineType() === ENGINE_KIND.WFG4;
   state.isImage = isImage;
   if(isImage){
     try {
@@ -12847,6 +12928,10 @@ async function prepareRunDocument(file){
       await renderImage(blobUrl);
       state.pageNum = 1; state.numPages = 1;
       if(els.pageControls) els.pageControls.style.display = 'none';
+      if(wfg4Selected){
+        await syncWfg4SurfaceContext('run');
+        return { type:'image' };
+      }
       const tokens = await ensureTokensForPage(1, null, state.pageViewports[0], els.imgCanvas);
       await buildKeywordIndexForPage(1, tokens, state.pageViewports[0]);
       // Keep URL alive while imgCanvas is active; cleanupDoc handles revocation.
@@ -12877,20 +12962,22 @@ async function prepareRunDocument(file){
     vp.pageNumber = i;
     state.pageViewports[i-1] = vp;
     state.pageOffsets[i-1] = totalH;
-    const rawTokens = await readTokensForPage(page, vp);
-    // pdf.js text items may be non-extensible in some browsers; clone before annotating
-    const tokens = rawTokens.map(t => ({ ...t, page: i }));
-    if(!state.pdfTextTokenCountByPage) state.pdfTextTokenCountByPage = {};
-    state.pdfTextTokenCountByPage[i] = tokens.length;
-    const acroTokens = await readAcroFormTokensForPage(i, page, vp);
-    const mergedTokens = mergePdfAndAcroTokens(tokens, acroTokens);
-    state.tokensByPage[i] = mergedTokens;
-    await buildKeywordIndexForPage(i, mergedTokens, vp);
-    if(isRunMode()) mirrorDebugLog(`[run-mode] tokens generated for page ${i}/${state.pdf.numPages}`);
+    if(!wfg4Selected){
+      const rawTokens = await readTokensForPage(page, vp);
+      // pdf.js text items may be non-extensible in some browsers; clone before annotating
+      const tokens = rawTokens.map(t => ({ ...t, page: i }));
+      if(!state.pdfTextTokenCountByPage) state.pdfTextTokenCountByPage = {};
+      state.pdfTextTokenCountByPage[i] = tokens.length;
+      const acroTokens = await readAcroFormTokensForPage(i, page, vp);
+      const mergedTokens = mergePdfAndAcroTokens(tokens, acroTokens);
+      state.tokensByPage[i] = mergedTokens;
+      await buildKeywordIndexForPage(i, mergedTokens, vp);
+      if(isRunMode()) mirrorDebugLog(`[run-mode] tokens generated for page ${i}/${state.pdf.numPages}`);
+    }
     // WFG4: populate the unified per-page raster cache from the pdf.js page.
     // This is the *same* rendering path that renderAllPages() uses in config
     // mode, so downstream WFG4 stages see identical pixels across modes.
-    if(getConfiguredEngineType() === ENGINE_KIND.WFG4){
+    if(wfg4Selected){
       await cacheWfg4PdfPageCanvas(i, page, vp);
     }
     totalH += vp.height;
@@ -12900,7 +12987,9 @@ async function prepareRunDocument(file){
   state.numPages = state.pdf.numPages;
   state.viewport = state.pageViewports[0] || { w:0, h:0, scale };
   state.overlayPinned = false;
-  await syncWfg4SurfaceContext('run');
+  if(wfg4Selected){
+    await syncWfg4SurfaceContext('run');
+  }
   return { type:'pdf' };
 }
 
@@ -20355,10 +20444,16 @@ els.confirmBtn?.addEventListener('click', async ()=>{
         const _workingDimsPre = _pageEntryPre?.dimensions?.working || null;
         const _originalDimsPre = _pageEntryPre?.dimensions?.original || null;
         const _wFallbackVp = getWfg4CanonicalViewport(state.pageNum, 'config') || state.pageViewports[state.pageNum-1] || state.viewport || {width:1,height:1};
+        const _displayVp = state.pageViewports?.[state.pageNum - 1] || _wFallbackVp;
+        const _canonicalDisplayActive = !!state.wfg4?.configDisplayActive;
         const _workW = Math.max(1, Number(_workingDimsPre?.width ?? _wFallbackVp.width ?? _wFallbackVp.w) || 1);
         const _workH = Math.max(1, Number(_workingDimsPre?.height ?? _wFallbackVp.height ?? _wFallbackVp.h) || 1);
-        const _dispW = Math.max(1, Number(_originalDimsPre?.width ?? _wFallbackVp.width ?? _wFallbackVp.w) || 1);
-        const _dispH = Math.max(1, Number(_originalDimsPre?.height ?? _wFallbackVp.height ?? _wFallbackVp.h) || 1);
+        const _dispW = _canonicalDisplayActive
+          ? Math.max(1, Number(_displayVp?.width ?? _displayVp?.w ?? _workW) || 1)
+          : Math.max(1, Number(_originalDimsPre?.width ?? _wFallbackVp.width ?? _wFallbackVp.w) || 1);
+        const _dispH = _canonicalDisplayActive
+          ? Math.max(1, Number(_displayVp?.height ?? _displayVp?.h ?? _workH) || 1)
+          : Math.max(1, Number(_originalDimsPre?.height ?? _wFallbackVp.height ?? _wFallbackVp.h) || 1);
         const _sX = _workW / _dispW;
         const _sY = _workH / _dispH;
         const _sRaw = state.snappedPx || { x:0, y:0, w:0, h:0 };
@@ -20377,6 +20472,18 @@ els.confirmBtn?.addEventListener('click', async ()=>{
         _rawBoxPre = { x: _wx, y: _wy, w: _ww, h: _wh, canvasW: _workW, canvasH: _workH };
         _normBoxPre = { x0n: _wx / _workW, y0n: _wy / _workH, wN: _ww / _workW, hN: _wh / _workH };
       }
+      console.log('[wfg4-box-debug]', {
+        sourceKind: state.isImage ? 'image' : 'pdf',
+        page: state.pageNum,
+        displayBoxPx: state.snappedPx || null,
+        workingBoxPx: _rawBoxPre || null,
+        normalizedBox: _normBoxPre || null,
+        captureFrame: captureFrame ? {
+          display: captureFrame.display,
+          working: captureFrame.working,
+          scale: captureFrame.scale
+        } : null
+      });
       _prelimEngineOwnedConfig = await EngineRegistry.registerFieldConfig(ENGINE_KIND.WFG4, {
         step,
         normBox: _normBoxPre,


### PR DESCRIPTION
### Motivation
- Fix incorrect OCR crops for PDFs when WFG4 canonical display is active by addressing a double-scaling of user-drawn display boxes that caused OCR to read pixels above/left of the selected region. 
- Consolidate the capture-frame as the single geometry authority so display vs working-space conversions are consistent across config/run modes. 
- Provide detailed forensic logging and disk artifacts to diagnose crop/scale mismatches during development and support.

### Description
- Change `buildCaptureFrame` in `engines/core/wfg4-capture-frame.js` to derive `displayW`/`displayH` from the active viewer viewport (`state.pageViewports[idx]`) when `state.wfg4.configDisplayActive` is true and compute a correct `working←display` scale (`sX`, `sY`).
- Rework `engines/core/wfg4-engine.js` to make the engine return a localized `finalReadoutBox` only and require an exact OCR crop readout (`wfg4-localized-ocr-required`) instead of in-engine token aggregation, and update emitted engine logs/metadata accordingly.
- Add a crop-driven OCR pipeline and debug artifact support in `invoice-wizard.js`, including `aggregateOcrWords`, `cropCanvasByBox`, `dumpWfg4CropDebugArtifact`, and `ocrWfg4CropReadout`, and integrate this pipeline into `extractFieldValue` to perform OCR against the canonical working surface (capture frame or cached page canvas) for WFG4 fields.
- Adjust file open/run flows to prefer WFG4 paths when selected (skip PDF text tokenization when `WFG4` engine is selected), and add console/file debug outputs (`[wfg4-box-debug]`, `[wfg4-crop-debug]`) plus written artifacts under `debug/wfg4-crops/` (`.png` and `.json`) for both PDF/image crops.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da80af0270832bac24699a8af64650)