### PR TITLE
Fix WFG4 run output drop by resolving run-time field engine from profile

### DIFF
--- a/invoice-wizard.js
+++ b/invoice-wizard.js
@@ -808,8 +808,16 @@ function resolveFieldEngineType(fieldSpec){
     // Prefer the stored per-field engine type (set at config time and carried in fieldSpec).
     // Fall back to the current dropdown only when the field has no explicit engine type
     // stored (e.g. legacy wizards created before per-field engineType was introduced).
-    const fieldEngine = normalizeEngineType(fieldSpec?.engineType || '');
-    const effectiveEngine = (fieldEngine !== ENGINE_KIND.LEGACY) ? fieldEngine : configuredEngine;
+    const rawFieldEngine = String(fieldSpec?.engineType || '').toLowerCase();
+    const fieldEngine = normalizeEngineType(rawFieldEngine);
+    if(rawFieldEngine === ENGINE_KIND.LEGACY){
+      return ENGINE_KIND.LEGACY;
+    }
+    const profileEngine = getProfileEngineType(state.profile);
+    const fallbackEngine = profileEngine !== ENGINE_KIND.LEGACY
+      ? profileEngine
+      : configuredEngine;
+    const effectiveEngine = (fieldEngine !== ENGINE_KIND.LEGACY) ? fieldEngine : fallbackEngine;
     if(
       effectiveEngine === ENGINE_KIND.WROKIT_VISION
       || effectiveEngine === ENGINE_KIND.AI_ALGO


### PR DESCRIPTION
### Motivation
- WFG4 runs completed but produced no saved output because fields were sometimes dispatched to the wrong extraction engine at run time, causing an empty extraction result and an early orchestration rejection.
- The change restores a correct run-mode engine handoff so WFG4 visual-only runs reach the WFG4 localization + OCR crop readout path and allow compile/persist to run.

### Description
- Updated `resolveFieldEngineType(fieldSpec)` in `invoice-wizard.js` to prefer the profile-level engine when a per-field `engineType` is missing during run mode, while still honoring an explicit `legacy` field marker. 
- Implemented a fallback chain in run mode: explicit `legacy` → per-field engine (if present) → profile engine → UI-configured engine, and return only supported runtime engine kinds (`wrokit_vision`, `ai_algo`, `wfg4`) otherwise treat as `legacy`.
- This prevents accidental routing of WFG4-configured runs to legacy extraction (which is token-dependent) when token prep is intentionally bypassed for WFG4, eliminating the `no_extracted_content` gate failure.
- Only the engine-resolution logic was changed; the WFG4 visual/OCR pipeline and token bypass remain untouched.

### Testing
- Ran `node test/run-mode-guards.test.js` which passed.
- Ran `node test/orchestrator.test.js` which passed.
- Ran `node test/master-db.test.js` which passed.
- Confirmed the change is limited to `invoice-wizard.js` (`resolveFieldEngineType`) and that WFG4 still uses the visual-only OCR crop readout path and persistence flows (`compileDocument` → `LS.setDb` → UI refresh) when fields are extracted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daaf9debf4832bafe7f0d21a6ae9e1)