### PR TITLE
Use WFG4OpenCv namespace for dataUrlToCanvas function

### DIFF
--- a/invoice-wizard.js
+++ b/invoice-wizard.js
@@ -10261,7 +10261,7 @@ async function applyAnyFieldVerifier(cleaned, { fieldKey, boxPx, pageNum, pageCa
       const pageEntry = wfg4Surface?.pages?.[Math.max(0, page - 1)] || null;
       const displayDataUrl = pageEntry?.artifacts?.displayDataUrl || null;
       if(displayDataUrl){
-        const pageCanvas = await dataUrlToCanvas(displayDataUrl);
+        const pageCanvas = await window.WFG4OpenCv?.dataUrlToCanvas(displayDataUrl);
         if(pageCanvas){
           sourceCanvas = pageCanvas;
           sourceLabel = 'wfg4Surface.page.artifacts.displayDataUrl';


### PR DESCRIPTION
## Summary
Updated the `applyAnyFieldVerifier` function to call `dataUrlToCanvas` through the `window.WFG4OpenCv` namespace instead of calling it as a global function.

## Key Changes
- Changed `dataUrlToCanvas(displayDataUrl)` to `window.WFG4OpenCv?.dataUrlToCanvas(displayDataUrl)` in the field verification logic
- Added optional chaining (`?.`) to safely access the function through the WFG4OpenCv namespace

## Implementation Details
This change ensures that the `dataUrlToCanvas` utility function is properly scoped within the WFG4OpenCv module, improving code organization and reducing potential naming conflicts with global scope. The optional chaining operator provides safe access in case the WFG4OpenCv object or its methods are not available.

https://claude.ai/code/session_01Q8ATxXWhD3qw2PLZrC9bBL