### PR TITLE
Add config debug overlay toggle with snapshot/restore of overlay flags

### DIFF
--- a/invoice-wizard.js
+++ b/invoice-wizard.js
@@ -610,6 +610,8 @@ const els = {
   showRingToggles: document.querySelectorAll('.show-ring-toggle'),
   showMatchToggles: document.querySelectorAll('.show-match-toggle'),
   showOcrBoxesToggle: document.getElementById('show-ocr-boxes-toggle'),
+  configDebugOverlayToggle: document.getElementById('config-debug-overlay-toggle'),
+  configDebugOverlayWrap: document.getElementById('config-debug-overlay-wrap'),
   showFeatureGraphToggle: document.getElementById('show-feature-graph-toggle'),
   showTextGraphToggle: document.getElementById('show-text-graph-toggle'),
   wrokitVisionFeatureGraphLayerPanel: document.getElementById('wrokitvision-feature-graph-layers'),
@@ -1938,6 +1940,8 @@ let state = {
   selectedRunId: '',
   lastSnapshotManifestId: '',
   snapshotPanels: { activePage: null },
+  configDebugOverlayEnabled: false,
+  configDebugOverlayPrevFlags: null,
   overlayPinned: false,
   overlayMetrics: null,
   isExtracting: false,
@@ -5491,6 +5495,18 @@ function isTextGraphEnabled(){
 }
 
 function getOverlayFlags(){
+  const persistedConfigOverlayOnly = !!state.configDebugOverlayEnabled && isConfigMode();
+  if(persistedConfigOverlayOnly){
+    return {
+      boxes: true,
+      rings: false,
+      matches: false,
+      ocr: false,
+      featureGraph: false,
+      textGraph: false,
+      featureGraphLayers: getFeatureGraphLayerFlags()
+    };
+  }
   const ringsOn = Array.from(els.showRingToggles||[]).some(t=>t.checked);
   const matchesOn = Array.from(els.showMatchToggles||[]).some(t=>t.checked);
   const visionOn = getConfiguredEngineType() === ENGINE_KIND.WROKIT_VISION || !!state.learningActive;
@@ -5523,6 +5539,69 @@ function syncFeatureGraphLayerVisibilityUI(){
     if(!toggle) return;
     toggle.disabled = !featureGraphOn;
   });
+}
+
+function setToggleChecked(toggle, checked){
+  if(!toggle) return;
+  toggle.checked = !!checked;
+}
+
+function snapshotConfigOverlayToggleState(){
+  return {
+    boxes: !!els.showBoxesToggle?.checked,
+    ocr: !!els.showOcrBoxesToggle?.checked,
+    featureGraph: !!els.showFeatureGraphToggle?.checked,
+    textGraph: !!els.showTextGraphToggle?.checked,
+    rings: Array.from(els.showRingToggles || []).map((node) => !!node.checked),
+    matches: Array.from(els.showMatchToggles || []).map((node) => !!node.checked),
+    wfg4StructuralOverlay: !!state.wfg4?.structuralOverlay
+  };
+}
+
+function restoreConfigOverlayToggleState(snapshot){
+  if(!snapshot) return;
+  setToggleChecked(els.showBoxesToggle, snapshot.boxes);
+  setToggleChecked(els.showOcrBoxesToggle, snapshot.ocr);
+  setToggleChecked(els.showFeatureGraphToggle, snapshot.featureGraph);
+  setToggleChecked(els.showTextGraphToggle, snapshot.textGraph);
+  (els.showRingToggles || []).forEach((node, idx) => setToggleChecked(node, snapshot.rings?.[idx]));
+  (els.showMatchToggles || []).forEach((node, idx) => setToggleChecked(node, snapshot.matches?.[idx]));
+  if(state.wfg4){
+    state.wfg4.structuralOverlay = !!snapshot.wfg4StructuralOverlay;
+  }
+  syncFeatureGraphLayerVisibilityUI();
+}
+
+function applyConfigDebugOverlayToggle(enabled){
+  const nextEnabled = !!enabled;
+  if(nextEnabled === !!state.configDebugOverlayEnabled){
+    if(els.configDebugOverlayToggle){
+      els.configDebugOverlayToggle.checked = nextEnabled;
+    }
+    return;
+  }
+  state.configDebugOverlayEnabled = nextEnabled;
+  if(els.configDebugOverlayToggle){
+    els.configDebugOverlayToggle.checked = nextEnabled;
+  }
+  if(nextEnabled){
+    state.configDebugOverlayPrevFlags = snapshotConfigOverlayToggleState();
+    setToggleChecked(els.showBoxesToggle, true);
+    setToggleChecked(els.showOcrBoxesToggle, false);
+    (els.showRingToggles || []).forEach((node) => setToggleChecked(node, false));
+    (els.showMatchToggles || []).forEach((node) => setToggleChecked(node, false));
+    setToggleChecked(els.showFeatureGraphToggle, false);
+    setToggleChecked(els.showTextGraphToggle, false);
+    if(state.wfg4){
+      state.wfg4.structuralOverlay = true;
+    }
+    syncFeatureGraphLayerVisibilityUI();
+  } else {
+    restoreConfigOverlayToggleState(state.configDebugOverlayPrevFlags);
+    state.configDebugOverlayPrevFlags = null;
+  }
+  markSnapshotsDirty();
+  drawOverlayForVisibilityChange();
 }
 
 function overlayFlagsEqual(a,b){
@@ -20402,6 +20481,9 @@ els.showBoxesToggle?.addEventListener('change', ()=>{ markSnapshotsDirty(); draw
 els.showRingToggles.forEach(t => t.addEventListener('change', ()=>{ markSnapshotsDirty(); drawOverlay(); }));
 els.showMatchToggles.forEach(t => t.addEventListener('change', ()=>{ markSnapshotsDirty(); drawOverlay(); }));
 els.showOcrBoxesToggle?.addEventListener('change', ()=>{ markSnapshotsDirty(); drawOverlay(); });
+els.configDebugOverlayToggle?.addEventListener('change', ()=>{
+  applyConfigDebugOverlayToggle(!!els.configDebugOverlayToggle.checked);
+});
 els.showFeatureGraphToggle?.addEventListener('change', ()=>{
   syncFeatureGraphLayerVisibilityUI();
   markSnapshotsDirty();

--- a/legacy/invoice-wizard.html
+++ b/legacy/invoice-wizard.html
@@ -276,6 +276,10 @@
             <input type="checkbox" id="show-match-wizard" class="show-match-toggle" />
             Show match points
           </label>
+          <label id="config-debug-overlay-wrap" style="margin-left:12px; display:flex; align-items:center; gap:6px;">
+            <input type="checkbox" id="config-debug-overlay-toggle" />
+            Show real config debug overlay
+          </label>
           <label id="wrokitvision-feature-graph-wrap" style="margin-left:12px; display:none; align-items:center; gap:6px;">
             <input type="checkbox" id="show-feature-graph-toggle" />
             Show Feature Graph


### PR DESCRIPTION
### Motivation
- Provide a dedicated UI toggle to view a configuration-focused debug overlay that forces a minimal set of overlay layers for inspecting configuration behavior.
- Preserve and restore the previous overlay visibility state when entering/exiting the config debug overlay so users can return to their prior visualization settings.

### Description
- Add a checkbox and wrapper (`#config-debug-overlay-toggle`, `#config-debug-overlay-wrap`) to the legacy HTML and expose it in the `els` registry. 
- Introduce new state properties `configDebugOverlayEnabled` and `configDebugOverlayPrevFlags` and wire them into `getOverlayFlags` to override normal overlay flags when config overlay mode is active. 
- Implement helper functions `setToggleChecked`, `snapshotConfigOverlayToggleState`, `restoreConfigOverlayToggleState`, and `applyConfigDebugOverlayToggle` to snapshot/restore UI toggle states and apply the config overlay behavior, including forcing `wfg4.structuralOverlay`. 
- Add an event listener to the new toggle to call `applyConfigDebugOverlayToggle`, and ensure UI layer toggles are synced via `syncFeatureGraphLayerVisibilityUI`, plus call `markSnapshotsDirty()` and `drawOverlayForVisibilityChange()` when mode changes.

### Testing
- Ran linting via `npm run lint` and static checks, which completed successfully. 
- Executed the existing unit test suite via `npm test`, which passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0a779490832ba6373a8a38c03cd2)