### PR TITLE
Add missing config debug overlay toggle to wizard config page

### DIFF
--- a/document-dashboard.html
+++ b/document-dashboard.html
@@ -1607,6 +1607,10 @@
           <input type="checkbox" id="show-match-wizard" class="show-match-toggle" />
           Show match points
         </label>
+        <label id="config-debug-overlay-wrap" style="margin-left:12px; display:flex; align-items:center; gap:6px;">
+          <input type="checkbox" id="config-debug-overlay-toggle" />
+          Show real config debug overlay
+        </label>
       </div>
 
       <div class="actions" id="wrokitvision-graph-controls" style="display:none; justify-content:flex-start; gap:12px; flex-wrap:wrap;">


### PR DESCRIPTION
### Motivation
- The debug toggle behavior (`applyConfigDebugOverlayToggle`) was implemented in `invoice-wizard.js` but the corresponding checkbox markup was present only in the legacy page and missing from the active wizard page, so users could not see or click it.

### Description
- Added the visible checkbox control to the active wizard controls in `document-dashboard.html` as `<label id="config-debug-overlay-wrap">` containing `<input id="config-debug-overlay-toggle" />` and label text `Show real config debug overlay`.
- No JS behavior changes were required because `invoice-wizard.js` already looks up `els.configDebugOverlayToggle`, attaches a `change` listener, and calls `applyConfigDebugOverlayToggle(...)` to enable the persisted-geometry-only overlay mode.
- The fix ensures the checkbox is rendered, clickable, and wired to the existing `applyConfigDebugOverlayToggle` logic so structural WFG4 overlay and boxes are toggled while runtime/transient overlays remain suppressed.

### Testing
- Ran the full automated test suite with `cd /workspace/Website && npm test` and all tests passed.
- Verified the checkbox markup is present alongside other wizard overlay controls in `document-dashboard.html` and that `invoice-wizard.js` wiring will react to the control (no JS errors at startup during tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd35771a4c832ba35d8bc0a004f6d1)