### PR TITLE
Add 'Show real config debug overlay' toggle to Wizard UI

### DIFF
--- a/document-dashboard.html
+++ b/document-dashboard.html
@@ -1591,6 +1591,13 @@
         <input id="wizard-file" type="file" accept="application/pdf,image/png,image/jpeg" />
       </div>
 
+      <div class="actions" id="config-debug-overlay-controls" style="justify-content:flex-start; gap:12px; flex-wrap:wrap;">
+        <label id="config-debug-overlay-wrap" style="display:flex; align-items:center; gap:6px;">
+          <input type="checkbox" id="config-debug-overlay-toggle" />
+          Show real config debug overlay
+        </label>
+      </div>
+
       <div class="actions" id="pageControls" style="display:none">
         <button id="prevPageBtn" class="btn">Prev Page</button>
         <span id="pageIndicator" class="sub">Page 1/1</span>


### PR DESCRIPTION
### Motivation
- Provide a UI control to enable the real configuration debug overlay during the wizard flow for easier debugging and inspection.

### Description
- Add a new `div` actions block with id `config-debug-overlay-controls` inside the `wizard-section` that contains a labeled checkbox with id `config-debug-overlay-toggle` and wrapper `config-debug-overlay-wrap` to toggle the real config debug overlay, styled with `justify-content:flex-start; gap:12px; flex-wrap:wrap;`.

### Testing
- No automated tests were run for this UI-only HTML change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd35771a4c832ba35d8bc0a004f6d1)