### PR TITLE
WFG4: prefer persisted config for debug overlay and redraw on page change

### DIFF
--- a/invoice-wizard.js
+++ b/invoice-wizard.js
@@ -16403,19 +16403,29 @@ function getCurrentWfg4ConfigDebugPacket(){
   if(!isWfg4StructuralOverlayActive()) return null;
   const step = state.steps?.[state.stepIdx] || null;
   const direct = step?.wfg4Config || null;
-  if(direct){
-    const page = Number(direct?.page || direct?.bbox?.page || state.pageNum || 1);
-    const liveBox = getWfg4LiveSelectionBoxForPage(page);
-    return liveBox ? buildWfg4LivePreviewPacket(direct, liveBox) : direct;
-  }
+  if(direct) return direct;
   const fieldKey = step?.fieldKey || null;
-  if(!fieldKey) return null;
-  const profileField = (state.profile?.fields || []).find(f => f && f.fieldKey === fieldKey);
-  const basePacket = profileField?.wfg4Config || null;
-  if(!basePacket) return null;
-  const page = Number(basePacket?.page || basePacket?.bbox?.page || state.pageNum || 1);
-  const liveBox = getWfg4LiveSelectionBoxForPage(page);
-  return liveBox ? buildWfg4LivePreviewPacket(basePacket, liveBox) : basePacket;
+  if(fieldKey){
+    const profileField = (state.profile?.fields || []).find(f => f && f.fieldKey === fieldKey);
+    const basePacket = profileField?.wfg4Config || null;
+    if(basePacket) return basePacket;
+  }
+
+  // Config debug overlay should remain truthful to persisted geometry even when
+  // the active step has no packet yet (e.g., first load or navigating to an
+  // unconfirmed field). Fall back to any persisted packet on the current page,
+  // then any persisted packet in the profile/steps.
+  const persisted = [];
+  for(const s of (state.steps || [])){
+    if(s?.wfg4Config) persisted.push(s.wfg4Config);
+  }
+  for(const f of (state.profile?.fields || [])){
+    if(f?.wfg4Config) persisted.push(f.wfg4Config);
+  }
+  if(!persisted.length) return null;
+  const currentPage = Number(state.pageNum || 1);
+  const pageMatch = persisted.find((pkt) => Number(pkt?.page || pkt?.bbox?.page || 1) === currentPage);
+  return pageMatch || persisted[0] || null;
 }
 
 function paintWfg4StructuralOverlay(ctx /*, legacyScaleX, legacyScaleY */){
@@ -17756,6 +17766,10 @@ els.viewer.addEventListener('scroll', ()=>{
     state.pageNum = p;
     if(state.pageViewports[p-1]) state.viewport = state.pageViewports[p-1];
     updatePageIndicator();
+    // Keep config debug overlays in sync with viewport/page changes.
+    // Without this redraw, overlay selection may stay bound to the previous
+    // page until another interaction event (draw/toggle) forces repaint.
+    drawOverlay({ skipGraphMapFetch: true });
   }
 });
 function drawOverlay(options = {}){


### PR DESCRIPTION
### Motivation
- Ensure the WFG4 debug/config overlay reflects persisted geometry rather than ephemeral live-selection transforms and stays in sync when the viewport/page changes.

### Description
- `getCurrentWfg4ConfigDebugPacket()` now returns direct/base `wfg4Config` packets without composing live-preview transforms and falls back to any persisted `wfg4Config` found in `state.steps` or `state.profile.fields`, preferring a packet that matches the current page.
- Added a redraw on page changes inside the viewer scroll handler by calling `drawOverlay({ skipGraphMapFetch: true })` so debug overlays update immediately when `state.pageNum` changes.
- Added inline comments explaining the rationale for keeping the debug overlay truthful to persisted geometry.

### Testing
- Ran the existing automated test suite and linters with `npm test` and `npm run lint`, and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd5c0db794832bb5e1b3e98c5b5f75)